### PR TITLE
Add `--name` to `web test run`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,8 @@
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node",
 	"mounts": [
-		"source=${env:HOME}${env:USERPROFILE}/.aws,target=/home/node/.aws,type=bind"
+		"source=${env:HOME}${env:USERPROFILE}/.aws,target=/home/node/.aws,type=bind",
+		"source=${env:HOME}${env:USERPROFILE}/.config/autify,target=/home/node/.config/autify,type=bind"
 	],
 	"features": {
 		"github-cli": "latest",

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ npm install -g autify-cli
 $ autify COMMAND
 running command...
 $ autify (--version)
-autify-cli/0.2.0-beta.0 linux-x64 node-v16.15.0
+autify-cli/0.2.0-beta.0 linux-x64 node-v16.14.0
 $ autify --help [COMMAND]
 USAGE
   $ autify COMMAND
@@ -436,14 +436,15 @@ Run a scenario or test plan.
 
 ```
 USAGE
-  $ autify web test run [SCENARIO-OR-TEST-PLAN-URL] [-r <value>] [--os <value>] [--os-version <value>] [--browser
-    <value>] [--device <value>] [--device-type <value>] [-w] [-t <value>] [-v]
+  $ autify web test run [SCENARIO-OR-TEST-PLAN-URL] [-n <value>] [-r <value>] [--os <value>] [--os-version
+    <value>] [--browser <value>] [--device <value>] [--device-type <value>] [-w] [-t <value>] [-v]
 
 ARGUMENTS
   SCENARIO-OR-TEST-PLAN-URL  Scenario URL or Test plan URL e.g.
                              https://app.autify.com/projects/<ID>/(scenarios|test_plans)/<ID>
 
 FLAGS
+  -n, --name=<value>                 Name of the test execution. (Only for test scenario execution.)
   -r, --url-replacements=<value>...  URL replacements. Example: http://example.com=http://example.net
   -t, --timeout=<value>              [default: 300] Timeout seconds when waiting for the finish of the test execution.
   -v, --verbose                      Verbose output
@@ -478,6 +479,10 @@ EXAMPLES
 
     $ autify web test run https://app.autify.com/projects/0000/scenarios/0000 -r \
       http://example.com=http://example.net -r http://example.org=http://example.net
+
+  Run a test with specifying the execution name:
+
+    $ autify web test run https://app.autify.com/projects/0000/scenarios/0000 --name "Sample execution"
 ```
 
 ## `autify web test wait TEST-RESULT-URL`

--- a/src/commands/web/test/run.ts
+++ b/src/commands/web/test/run.ts
@@ -31,9 +31,11 @@ export default class WebTestRun extends Command {
     'Run and wait a test scenario:\n<%= config.bin %> <%= command.id %> https://app.autify.com/projects/0000/scenarios/0000 --wait --timeout 600',
     'Run a test scenario with a specific capability:\n<%= config.bin %> <%= command.id %> https://app.autify.com/projects/0000/scenarios/0000 --os "Windows Server" --browser Edge',
     'With URL replacements:\n<%= config.bin %> <%= command.id %> https://app.autify.com/projects/0000/scenarios/0000 -r http://example.com=http://example.net -r http://example.org=http://example.net',
+    'Run a test with specifying the execution name:\n<%= config.bin %> <%= command.id %> https://app.autify.com/projects/0000/scenarios/0000 --name "Sample execution"',
   ]
 
   static flags = {
+    name: Flags.string({char: 'n', description: 'Name of the test execution. (Only for test scenario execution.)'}),
     'url-replacements': Flags.string({char: 'r', description: 'URL replacements. Example: http://example.com=http://example.net', multiple: true}),
     os: Flags.string({description: 'OS to run the test'}),
     'os-version': Flags.string({description: 'OS version to run the test'}),
@@ -63,7 +65,11 @@ export default class WebTestRun extends Command {
     const urlReplacements = parseUrlReplacements(flags['url-replacements'] ?? [])
     if (urlReplacements.length > 0) this.log(`${emoji.get('memo')} Using URL replacements: ${urlReplacementsToString(urlReplacements)}`)
     const client = new Client(this.config.configDir, this.config.userAgent)
-    const {workspaceId, resultId, capability} = await runTest(client, args['scenario-or-test-plan-url'], capabilityOption, urlReplacements)
+    const {workspaceId, resultId, capability} = await runTest(client, args['scenario-or-test-plan-url'], {
+      option: capabilityOption,
+      name: flags.name,
+      urlReplacements,
+    })
     const testResultUrl = getWebTestResultUrl(this.config.configDir, workspaceId, resultId)
     this.log(`${emoji.get('white_check_mark')} Successfully started: ${testResultUrl} (Capability is ${capability})`)
     if (flags.wait) {


### PR DESCRIPTION
This commit adds a new option `--name` to `web test run`.
It enables the user to set the test execution name if the target is
a test scenario, not a test plan.