### PR TITLE
Add publish workflow

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,6 +12,7 @@ runs:
     - uses: actions/setup-node@v3.2.0
       with:
         cache: npm
+        registry-url: "https://registry.npmjs.org"
     - run: npm install
       shell: bash
     - uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -97,7 +97,18 @@ jobs:
       - uses: ./.github/actions/install
         with:
           target: brew
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # TODO: Remove after public
       - run: echo test | autify web auth login
       - run: npm run test:integration
+
+  npm:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: ./.github/actions/install
+        with:
+          target: npm
+      - run: echo test | autify web auth login
+      - run: autify-cli-integration-test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,8 @@
-name: Promote
+name: Publish
 
 on:
-  workflow_call:
-    secrets:
-      BOT_APP_ID:
-        required: true
-      BOT_PRIVATE_KEY:
-        required: true
+  release:
+    types: [published]
 
 permissions:
   id-token: write
@@ -25,7 +21,16 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ steps.generate-token.outputs.token }}
+      - uses: actions/checkout@v3
+        with:
+          repository: autifyhq/homebrew-tap
+          path: homebrew-tap
+          token: ${{ steps.generate-token.outputs.token }}
       - uses: ./.github/actions/setup
         with:
           aws-credentials: ${{ github.ref_name }}
-      - run: npm run release promote
+      - run: git config --global user.name "${GITHUB_ACTOR}"
+      - run: git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+      - run: npm run release publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_RELEASE_TOKEN}}

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -54,6 +54,17 @@ jobs:
         with:
           target: macos
 
+  npm:
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: ./.github/actions/upload
+        with:
+          target: npm
+
   # Not supported yet: https://github.com/oclif/oclif/issues/887
   #deb:
   #  runs-on: 'ubuntu-latest'

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /yarn.lock
 node_modules
 oclif.manifest.json
+*.tgz

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ npm install -g @autifyhq/autify-cli
 $ autify COMMAND
 running command...
 $ autify (--version)
-@autifyhq/autify-cli/0.3.0-beta.0 linux-x64 node-v16.14.0
+@autifyhq/autify-cli/0.3.0-beta.0 linux-arm64 node-v16.14.2
 $ autify --help [COMMAND]
 USAGE
   $ autify COMMAND

--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@autifyhq/autify-cli-integration-test",
   "version": "0.3.0-beta.0",
-  "private": true,
   "description": "Autify Command Line Interface (CLI) Integration Test",
   "author": "Autify",
   "bin": {
@@ -43,6 +42,7 @@
   },
   "scripts": {
     "build": "shx rm -rf dist && tsc -b",
+    "prepack": "npm run build",
     "test": "jest dist/test",
     "test:record": "AUTIFY_POLLY_RECORD=1 npm run test -- --updateSnapshot"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@autifyhq/autify-cli",
   "version": "0.3.0-beta.0",
-  "private": true,
   "description": "Autify Command Line Interface (CLI)",
   "author": "Autify",
   "bin": {
@@ -102,7 +101,9 @@
     }
   },
   "scripts": {
-    "postinstall": "patch-package",
+    "postinstall": "per-env || true",
+    "postinstall:development": "patch-package",
+    "postinstall:production": "true",
     "generate:api-commands": "ts-node scripts/generate-api-commands.ts",
     "generate": "npm run generate:api-commands web && npm run generate:api-commands mobile",
     "build": "shx rm -rf dist && tsc -b",


### PR DESCRIPTION
To trigger stable promotion by GitHub release, this commit introduces
a new workflow "Publish" that executes S3 promotion, Homebrew update and
npm publish.

Note: This commit is WIP to test the workflow for beta publish.
Need to comment out in `publishCommand()` of `scripts/release.ts`.