### PR TITLE
Fix TODO for publish and minor dependencies

### DIFF
--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -28,7 +28,8 @@
     "express": "^4.18.1",
     "http-proxy-middleware": "^2.0.6",
     "jest": "^28.1.1",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.0",
+    "which": "^2.0.2"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
@@ -37,8 +38,7 @@
     "@types/which": "^2.0.1",
     "shx": "^0.3.4",
     "ts-node": "^10.8.1",
-    "typescript": "^4.7.3",
-    "which": "^2.0.2"
+    "typescript": "^4.7.3"
   },
   "scripts": {
     "build": "shx rm -rf dist && tsc -b",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "integration-test"
       ],
       "dependencies": {
-        "@autifyhq/autify-sdk": "*",
+        "@autifyhq/autify-sdk": "^0.1.0",
         "@oclif/core": "^1",
         "@oclif/errors": "^1.3.5",
         "@oclif/plugin-help": "^5",
@@ -70,7 +70,8 @@
         "express": "^4.18.1",
         "http-proxy-middleware": "^2.0.6",
         "jest": "^28.1.1",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.0",
+        "which": "^2.0.2"
       },
       "bin": {
         "autify-cli-integration-test": "bin/autify-cli-integration-test.js",
@@ -83,8 +84,7 @@
         "@types/which": "^2.0.1",
         "shx": "^0.3.4",
         "ts-node": "^10.8.1",
-        "typescript": "^4.7.3",
-        "which": "^2.0.2"
+        "typescript": "^4.7.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -107,9 +107,9 @@
       "link": true
     },
     "node_modules/@autifyhq/autify-sdk": {
-      "version": "0.1.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@autifyhq/autify-sdk/-/autify-sdk-0.1.0-beta.2.tgz",
-      "integrity": "sha512-sT34qAzdKsTqb8V64LAshGHzDMuWkaJt47fTFFhXdkp4lJXCZrk5dbb6ts+dNALM0WlUuxpgnj7TKu7QFHbAPw==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@autifyhq/autify-sdk/-/autify-sdk-0.1.0.tgz",
+      "integrity": "sha512-oMbJc7yeiIN/HPdPrRy5MmULo4VBOby2CJlJZyfYvmGlmkGU6LUF5NDK2HvXkp6GK1vg1NYt1TZLa3XTFMy6Ww==",
       "dependencies": {
         "axios": "^0.27.2",
         "axios-logger": "^2.6.1",
@@ -13544,9 +13544,9 @@
       }
     },
     "@autifyhq/autify-sdk": {
-      "version": "0.1.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@autifyhq/autify-sdk/-/autify-sdk-0.1.0-beta.2.tgz",
-      "integrity": "sha512-sT34qAzdKsTqb8V64LAshGHzDMuWkaJt47fTFFhXdkp4lJXCZrk5dbb6ts+dNALM0WlUuxpgnj7TKu7QFHbAPw==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@autifyhq/autify-sdk/-/autify-sdk-0.1.0.tgz",
+      "integrity": "sha512-oMbJc7yeiIN/HPdPrRy5MmULo4VBOby2CJlJZyfYvmGlmkGU6LUF5NDK2HvXkp6GK1vg1NYt1TZLa3XTFMy6Ww==",
       "requires": {
         "axios": "^0.27.2",
         "axios-logger": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "/oclif.manifest.json"
   ],
   "dependencies": {
-    "@autifyhq/autify-sdk": "*",
+    "@autifyhq/autify-sdk": "^0.1.0",
     "@oclif/core": "^1",
     "@oclif/errors": "^1.3.5",
     "@oclif/plugin-help": "^5",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -194,11 +194,10 @@ const publishNpm = () => {
 const publishCommand = () => {
   const tag = execSync("git tag --points-at HEAD").toString();
   if (tag === "") throw new Error("Publish only supports a tagged commit.");
-  // TODO: Uncomment
-  // if (channel !== "stable")
-  //   throw new Error(`Publish only supports stable channel: ${channel}`);
-  // promoteS3();
-  // publishBrew();
+  if (channel !== "stable")
+    throw new Error(`Publish only supports stable channel: ${channel}`);
+  promoteS3();
+  publishBrew();
   publishNpm();
 };
 


### PR DESCRIPTION
We verified the publish workflow works with beta version.
Thus, we can remove the TODO to prepare 0.3.0 release.

Also, fixed minor dependencies including using @autifyhq/autify-sdk@0.1.0.