### PR TITLE
Change interval weekly → monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     versioning-strategy: increase
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "dependencies"
     open-pull-requests-limit: 100
@@ -17,4 +17,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
I believe that the Dependabot is making the PR regardless of Interval for the vulnerable one. If this assumption is true, I'm wondering if it would be a bit tedious and hard to maintain to check the versions of other dependencies weekly? 

What do you think?