### PR TITLE
Fix aws-credentials for publish workflow

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -28,7 +28,7 @@ runs:
         role-session-name: github-actions
         aws-region: us-west-2
     - uses: aws-actions/configure-aws-credentials@v1
-      if: ${{ startsWith(inputs.aws-credentials, 'releases/') }}
+      if: ${{ startsWith(inputs.aws-credentials, 'releases/') || inputs.aws-credentials == 'publish' }}
       with:
         role-to-assume: arn:aws:iam::434848343351:role/autify-cli-release-role
         role-session-name: github-actions

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
       - uses: ./.github/actions/setup
         with:
-          aws-credentials: ${{ github.ref_name }}
+          aws-credentials: publish
       - run: git config --global user.name "${GITHUB_ACTOR}"
       - run: git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
       - run: npm run release publish


### PR DESCRIPTION
Since we switched the trigger for publish to `release`,
`github.ref_name` is the tag name, not its branch name.

Therefore, we need to adjust the `setup` action to deal it differently.

Note: Need to cherry-pick to `main` branch once confirmed it's working expectedly.