### PR TITLE
Fix bump command for stable

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -349,7 +349,7 @@ const bumpCommand = () => {
   } else if (branch.startsWith("releases/")) {
     if (channel.endsWith("-rc")) {
       // 0.1.0-rc.0 => 0.1.0
-      pushToBumpBranch("stable", "npm version minor --no-git-tag-version");
+      pushToBumpBranch("stable", "npm version patch --no-git-tag-version");
     } else if (channel === "stable") {
       // 0.1.0 => 0.1.1-rc.0
       pushToBumpBranch(


### PR DESCRIPTION
Previously, the command was wrong especially when bumping from
`0.1.1-rc.0` to `0.1.1`. It bumped to `0.2.0` mistakenly:

```
$ npm version prerelease --preid rc --no-git-tag-version
v0.1.0-rc.0
$ npm version minor --no-git-tag-version
v0.1.0
$ npm version prepatch --preid rc --no-git-tag-version
v0.1.1-rc.0
$ npm version minor --no-git-tag-version
v0.2.0
```

By this change, it correctly bumps versions:

```
$ npm version prerelease --preid rc --no-git-tag-version
v0.1.0-rc.0
$ npm version patch --no-git-tag-version
v0.1.0
$ npm version prepatch --preid rc --no-git-tag-version
v0.1.1-rc.0
$ npm version patch --no-git-tag-version
v0.1.1
```

Note: This commit needs to be cherry-picked to `main`.