### PR TITLE
Add install-cicd.bash

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -61,11 +61,8 @@ jobs:
   shell:
     strategy:
       matrix:
-        include:
-          - target: linux-x64
-            os: ubuntu-latest
-          - target: darwin-x64
-            os: macos-latest
+        os: [ubuntu-latest, macos-latest]
+        target: [standalone-shell, cicd-shell]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -76,7 +73,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/install
         with:
-          target: shell
+          target: ${{ matrix.target }}
       - run: echo test | autify web auth login
       - run: npm run test:integration
 

--- a/install-cicd.bash
+++ b/install-cicd.bash
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+echoerr() { echo "\$@" 1>&2; }
+
+if [ "$(uname)" == "Darwin" ]; then
+  OS=darwin
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+  OS=linux
+else
+  echoerr "This installer is only supported on Linux and macOS"
+  exit 1
+fi
+
+ARCH="$(uname -m)"
+if [ "$ARCH" == "x86_64" ]; then
+  ARCH=x64
+elif [[ "$ARCH" == aarch* ]]; then
+  ARCH=arm
+elif [ "$ARCH" == "arm64" ]; then
+  ARCH=arm64
+else
+  echoerr "Unsupported arch: $ARCH"
+  exit 1
+fi
+
+AUTIFY_S3_BUCKET=REPLACE
+AUTIFY_S3_PREFIX=REPLACE
+
+WORKSPACE="$(pwd)"
+mkdir -p ./autify/bin
+mkdir -p ./autify/lib
+cd ./autify/lib
+
+if [ $(command -v xz) ]; then
+  TAR_EXT="tar.xz"
+  TAR_ARGS="xJ"
+else
+  TAR_EXT="tar.gz"
+  TAR_ARGS="xz"
+fi
+
+URL=https://$AUTIFY_S3_BUCKET.s3.amazonaws.com/$AUTIFY_S3_PREFIX-$OS-$ARCH.$TAR_EXT
+echo "Installing CLI from $URL"
+if [ $(command -v curl) ]; then
+  curl "$URL" | tar "$TAR_ARGS"
+else
+  wget -O- "$URL" | tar "$TAR_ARGS"
+fi
+
+cd "$WORKSPACE"
+ln -s "$WORKSPACE/autify/lib/autify/bin/autify" "$WORKSPACE/autify/bin/autify"
+
+"$WORKSPACE/autify/bin/autify" --version


### PR DESCRIPTION
As we grow more integrations, some CI/CD solutions want to install
Autify CLI in current working directory. `install-cicd.bash` is a variant
of `install-standalone.sh` to install Autify CLI to CWD.