### PR TITLE
Delete previously installed files in `install-cicd.bash`

### DIFF
--- a/install-cicd.bash
+++ b/install-cicd.bash
@@ -28,6 +28,7 @@ AUTIFY_S3_BUCKET=REPLACE
 AUTIFY_S3_PREFIX=REPLACE
 
 WORKSPACE="$(pwd)"
+rm -fr ./autify
 mkdir -p ./autify/bin
 mkdir -p ./autify/lib
 cd ./autify/lib


### PR DESCRIPTION
Sometimes the workspace is reused in CI/CD solutions and
the previously installed files should be delete before install.