### PR TITLE
Add `mobile test run/wait`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ npm install -g @autifyhq/autify-cli
 $ autify COMMAND
 running command...
 $ autify (--version)
-@autifyhq/autify-cli/0.6.0-beta.0 linux-x64 node-v16.16.0
+@autifyhq/autify-cli/0.6.0-beta.0 linux-x64 node-v16.14.0
 $ autify --help [COMMAND]
 USAGE
   $ autify COMMAND
@@ -66,6 +66,8 @@ After the installation, you can always get the latest update on `stable` channel
 - [`autify mobile api run-test-plan`](#autify-mobile-api-run-test-plan)
 - [`autify mobile api upload-build`](#autify-mobile-api-upload-build)
 - [`autify mobile auth login`](#autify-mobile-auth-login)
+- [`autify mobile test run TEST-PLAN-URL BUILD-PATH`](#autify-mobile-test-run-test-plan-url-build-path)
+- [`autify mobile test wait TEST-RESULT-URL`](#autify-mobile-test-wait-test-result-url)
 - [`autify update [CHANNEL]`](#autify-update-channel)
 - [`autify web api create-url-replacement`](#autify-web-api-create-url-replacement)
 - [`autify web api delete-url-replacement`](#autify-web-api-delete-url-replacement)
@@ -200,6 +202,58 @@ EXAMPLES
   Reading the token from file:
 
     $ autify mobile auth login < token.txt
+```
+
+## `autify mobile test run TEST-PLAN-URL BUILD-PATH`
+
+Run a test plan.
+
+```
+USAGE
+  $ autify mobile test run [TEST-PLAN-URL] [BUILD-PATH] [-w] [-t <value>] [-v]
+
+ARGUMENTS
+  TEST-PLAN-URL  Test plan URL e.g. https://mobile-app.autify.com/projects/<ID>/test_plans/<ID>
+  BUILD-PATH     File path to the iOS app (*.app) or Android app (*.apk).
+
+FLAGS
+  -t, --timeout=<value>  [default: 300] Timeout seconds when waiting for the finish of the test execution.
+  -v, --verbose          Verbose output
+  -w, --wait             Wait until the test finishes.
+
+DESCRIPTION
+  Run a test plan.
+
+EXAMPLES
+  Run a test plan:
+
+    $ autify mobile test run https://mobile-app.autify.com/projects/AAA/test_plans/BBB ./my.app
+
+  Run and wait a test plan:
+
+    $ autify mobile test run https://mobile-app.autify.com/projects/AAA/test_plans/BBB ./my.app --wait --timeout 600
+```
+
+## `autify mobile test wait TEST-RESULT-URL`
+
+Wait a test result until it finishes.
+
+```
+USAGE
+  $ autify mobile test wait [TEST-RESULT-URL] [-t <value>] [-v]
+
+ARGUMENTS
+  TEST-RESULT-URL  Test result URL e.g. https://mobile-app.autify.com/projects/<ID>/results/<ID>
+
+FLAGS
+  -t, --timeout=<value>  [default: 300] Timeout seconds when waiting for the finish of the test execution.
+  -v, --verbose          Verbose output
+
+DESCRIPTION
+  Wait a test result until it finishes.
+
+EXAMPLES
+  $ autify mobile test wait https://mobile-app.autify.com/projects/AAA/results/BBB
 ```
 
 ## `autify update [CHANNEL]`

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,10 @@
         "inquirer": "^8.2.4",
         "listr": "^0.14.3",
         "node-emoji": "^1.11.0",
-        "per-env": "^1.0.2"
+        "per-env": "^1.0.2",
+        "tempy": "^3.0.0",
+        "tsimportlib": "^0.0.3",
+        "which": "^2.0.2"
       },
       "bin": {
         "autify": "bin/run"
@@ -3954,6 +3957,31 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dargs": {
@@ -11869,6 +11897,53 @@
         "node": ">=10"
       }
     },
+    "node_modules/temp-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tempy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.0.0.tgz",
+      "integrity": "sha512-B2I9X7+o2wOaW4r/CWMkpOO9mdiTRCxXNgob6iGvPmfPWgH/KyUD6Uy5crtWBxIBe3YrNZKR2lSzv1JJKWD4vA==",
+      "dependencies": {
+        "is-stream": "^3.0.0",
+        "temp-dir": "^2.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/type-fest": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -12058,6 +12133,11 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/tsimportlib": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tsimportlib/-/tsimportlib-0.0.3.tgz",
+      "integrity": "sha512-U9sW2/3D0P4IVRnhH2RCqjCP0sG66qvb4ahB0aQln5xGMphDjntz5rdk0rFZ6Fg+lW3L+i+gRnIl4VvNBvxiQw=="
+    },
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
@@ -12176,6 +12256,20 @@
       "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
+      }
+    },
+    "node_modules/unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "dependencies": {
+        "crypto-random-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/universal-user-agent": {
@@ -16185,6 +16279,21 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      }
+    },
+    "crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "requires": {
+        "type-fest": "^1.0.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+        }
       }
     },
     "dargs": {
@@ -22095,6 +22204,34 @@
         "readable-stream": "^3.1.1"
       }
     },
+    "temp-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg=="
+    },
+    "tempy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.0.0.tgz",
+      "integrity": "sha512-B2I9X7+o2wOaW4r/CWMkpOO9mdiTRCxXNgob6iGvPmfPWgH/KyUD6Uy5crtWBxIBe3YrNZKR2lSzv1JJKWD4vA==",
+      "requires": {
+        "is-stream": "^3.0.0",
+        "temp-dir": "^2.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="
+        },
+        "type-fest": {
+          "version": "2.18.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+          "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw=="
+        }
+      }
+    },
     "terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -22225,6 +22362,11 @@
         }
       }
     },
+    "tsimportlib": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tsimportlib/-/tsimportlib-0.0.3.tgz",
+      "integrity": "sha512-U9sW2/3D0P4IVRnhH2RCqjCP0sG66qvb4ahB0aQln5xGMphDjntz5rdk0rFZ6Fg+lW3L+i+gRnIl4VvNBvxiQw=="
+    },
     "tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
@@ -22314,6 +22456,14 @@
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
+      }
+    },
+    "unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "requires": {
+        "crypto-random-string": "^4.0.0"
       }
     },
     "universal-user-agent": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
     "inquirer": "^8.2.4",
     "listr": "^0.14.3",
     "node-emoji": "^1.11.0",
-    "per-env": "^1.0.2"
+    "per-env": "^1.0.2",
+    "tempy": "^3.0.0",
+    "tsimportlib": "^0.0.3",
+    "which": "^2.0.2"
   },
   "devDependencies": {
     "@autifyhq/autify-cli-integration-test": "*",

--- a/src/autify/mobile/createZip.ts
+++ b/src/autify/mobile/createZip.ts
@@ -1,0 +1,52 @@
+/* eslint-disable unicorn/filename-case */
+
+import { CLIError } from "@oclif/errors";
+import { execFileSync } from "node:child_process";
+import { lstatSync } from "node:fs";
+import { platform } from "node:os";
+import { basename, dirname, resolve } from "node:path";
+import which from "which";
+import { dynamicImport } from "tsimportlib";
+
+const checkPlatform = () => {
+  const supportedPlatforms: NodeJS.Platform[] = ["linux", "darwin"];
+  const p = platform();
+  if (!supportedPlatforms.includes(p)) {
+    throw new CLIError(
+      `${p} is not supported to zip file. Only supports: ${supportedPlatforms}`
+    );
+  }
+};
+
+const checkBuildPath = (buildPath: string) => {
+  if (!lstatSync(buildPath).isDirectory()) {
+    throw new CLIError(`Build path (${buildPath}) is expected to directory.`);
+  }
+
+  const parentPath = resolve(dirname(buildPath));
+  const name = basename(buildPath);
+  return [parentPath, name];
+};
+
+const findZip = () => {
+  const zip = which.sync("zip", { nothrow: true });
+  if (!zip) {
+    throw new CLIError("Can't find zip command in PATH.");
+  }
+
+  return zip;
+};
+
+export const createZip = async (buildPath: string): Promise<string> => {
+  checkPlatform();
+  const [parentPath, name] = checkBuildPath(buildPath);
+  const zip = findZip();
+  const { temporaryFile } = (await dynamicImport(
+    "tempy",
+    // eslint-disable-next-line unicorn/prefer-module
+    module
+  )) as typeof import("tempy");
+  const zipFile = temporaryFile({ name: "build.zip" });
+  execFileSync(zip, ["-r", zipFile, name], { cwd: parentPath });
+  return zipFile;
+};

--- a/src/autify/mobile/getTestResultUrl.ts
+++ b/src/autify/mobile/getTestResultUrl.ts
@@ -1,0 +1,15 @@
+/* eslint-disable unicorn/filename-case */
+import { MOBILE_BASE_PATH } from "@autifyhq/autify-sdk";
+import { get } from "../../config";
+
+export const getMobileTestResultUrl = (
+  configDir: string,
+  workspaceId: string,
+  resultId: string
+): string => {
+  // Currently, it's heuristic. We could provide a new API or include the URL in the response of the existing APIs.
+  let basePath = get(configDir, "AUTIFY_MOBILE_BASE_PATH") ?? MOBILE_BASE_PATH;
+  if (basePath.startsWith("http://localhost:")) basePath = MOBILE_BASE_PATH; // Override if it's running integration tests.
+  const endpoint = basePath.slice(0, Math.max(0, basePath.indexOf("/api/v1"))); // Assuming the UI endpoint is the same as API endpoint.
+  return `${endpoint}/projects/${workspaceId}/results/${resultId}`;
+};

--- a/src/autify/mobile/parseTestResultUrl.ts
+++ b/src/autify/mobile/parseTestResultUrl.ts
@@ -1,0 +1,15 @@
+/* eslint-disable unicorn/filename-case */
+import { CLIError } from "@oclif/errors";
+
+export const parseTestResultUrl = (
+  url: string
+): { workspaceId: string; resultId: string } => {
+  const { pathname } = new URL(url);
+  const testResultUrlPathRegExp =
+    /\/projects\/(?<workspaceId>[^/]+)\/results\/(?<resultId>[^/]+)/;
+  const match = testResultUrlPathRegExp.exec(pathname);
+  const workspaceId = match?.groups?.workspaceId;
+  const resultId = match?.groups?.resultId;
+  if (!workspaceId || !resultId) throw new CLIError(`Invalid URL: ${url}`);
+  return { workspaceId, resultId };
+};

--- a/src/autify/mobile/runTest.ts
+++ b/src/autify/mobile/runTest.ts
@@ -1,0 +1,66 @@
+/* eslint-disable unicorn/filename-case */
+import { MobileClient } from "@autifyhq/autify-sdk";
+import { CLIError } from "@oclif/errors";
+import { lstatSync } from "node:fs";
+import { createZip } from "./createZip";
+
+const parseTestPlanUrl = (url: string) => {
+  const { pathname } = new URL(url);
+  const testPlanUrlPathRegExp =
+    /\/projects\/(?<workspaceId>[^/]+)\/test_plans\/(?<testPlanId>[^/]+)/;
+  const match = testPlanUrlPathRegExp.exec(pathname);
+  const workspaceId = match?.groups?.workspaceId;
+  const testPlanId = match?.groups?.testPlanId;
+  if (!workspaceId || !testPlanId) return;
+  return { workspaceId, testPlanId };
+};
+
+const isIosApp = (buildPath: string) => {
+  return (
+    lstatSync(buildPath).isDirectory() &&
+    buildPath.replace(/\/$/, "").endsWith(".app")
+  );
+};
+
+const isAndroidApp = (buildPath: string) => {
+  return lstatSync(buildPath).isFile() && buildPath.endsWith(".apk");
+};
+
+const uploadBuild = async (
+  client: MobileClient,
+  projectId: string,
+  buildPath: string
+) => {
+  if (isIosApp(buildPath)) {
+    const zipFile = await createZip(buildPath);
+    const res = await client.uploadBuild(projectId, zipFile);
+    return res.data.id;
+  }
+
+  if (isAndroidApp(buildPath)) {
+    const res = await client.uploadBuild(projectId, buildPath);
+    return res.data.id;
+  }
+
+  throw new CLIError(`${buildPath} doesn't look like iOS app nor Android apk.`);
+};
+
+export const runTest = async (
+  client: MobileClient,
+  url: string,
+  buildPath: string
+): Promise<{ workspaceId: string; resultId: string }> => {
+  const testPlan = parseTestPlanUrl(url);
+  if (testPlan) {
+    const { workspaceId, testPlanId } = testPlan;
+    const buildId = await uploadBuild(client, workspaceId, buildPath);
+    const res = await client.runTestPlan(testPlanId, {
+      // eslint-disable-next-line camelcase
+      build_id: buildId,
+    });
+    const resultId = res.data.id ?? "";
+    return { workspaceId, resultId };
+  }
+
+  throw new CLIError(`Invalid URL: ${url}`);
+};

--- a/src/autify/mobile/waitTestResult.ts
+++ b/src/autify/mobile/waitTestResult.ts
@@ -1,0 +1,93 @@
+/* eslint-disable unicorn/filename-case */
+import { CLIError } from "@oclif/errors";
+import Listr, { ListrTaskWrapper } from "listr";
+import { setInterval } from "node:timers/promises";
+import { MobileClient } from "@autifyhq/autify-sdk";
+import emoji from "node-emoji";
+
+const waitUntil = async <T>(
+  callback: (task: ListrTaskWrapper<{ result: T }>) => Promise<T>,
+  timeoutSecond: number,
+  intervalSecond: number,
+  verbose: boolean
+): Promise<T | void> => {
+  const task = new Listr<{ result: T }>(
+    [
+      {
+        title: `Waiting... (timeout: ${timeoutSecond} s)`,
+        task: async (ctx, task) => {
+          for await (const startTime of setInterval(
+            intervalSecond * 1000,
+            Date.now()
+          )) {
+            const now = Date.now();
+            if (now - startTime > timeoutSecond * 1000) {
+              throw new CLIError(`Timeout after ${timeoutSecond} seconds.`);
+            }
+
+            const result = await callback(task);
+            if (result) {
+              ctx.result = result;
+              return;
+            }
+          }
+        },
+      },
+    ],
+    {
+      renderer: verbose ? "verbose" : "default",
+      nonTTYRenderer: "verbose",
+    }
+  );
+  return (await task.run()).result;
+};
+
+type Status = Awaited<
+  ReturnType<MobileClient["describeTestResult"]>
+>["data"]["status"];
+
+const emojiStatus = (status?: Status) => {
+  if (status === "queuing") return emoji.get("cyclone") + " Queuing";
+  if (status === "waiting")
+    return emoji.get("hourglass_flowing_sand") + " Waiting";
+  if (status === "running") return emoji.get("car") + " Running";
+  if (status === "passed") return emoji.get("+1") + " Passed ";
+  if (status === "failed") return emoji.get("rotating_light") + " Failed ";
+  if (status === "skipped") return emoji.get("zzz") + " Skipped";
+  return emoji.get("grey_question") + " None   ";
+};
+
+const describeTestResult =
+  (client: MobileClient, workspaceId: string, resultId: string) =>
+  async (task: ListrTaskWrapper) => {
+    const { data } = await client.describeTestResult(workspaceId, resultId);
+    const testPlanStatus = emojiStatus(data.status);
+    const testCaseStatus: string[] = [];
+    for (const testCaseResult of data.test_case_results ?? []) {
+      testCaseStatus.push(emojiStatus(testCaseResult.status));
+    }
+
+    task.output = `TestPlan: ${testPlanStatus}, TestCases: ${testCaseStatus.join(
+      " / "
+    )}`;
+    if (data.finished_at) return data;
+  };
+
+export const waitTestResult = async (
+  client: MobileClient,
+  workspaceId: string,
+  resultId: string,
+  options: { timeoutSecond: number; verbose: boolean }
+): Promise<{ isPassed: boolean; data: any }> => {
+  const data = await waitUntil(
+    describeTestResult(client, workspaceId, resultId),
+    options.timeoutSecond,
+    1,
+    options.verbose
+  );
+  const isPassed = data?.status === "passed";
+  return {
+    isPassed,
+    data,
+  };
+};

--- a/src/commands/mobile/test/run.ts
+++ b/src/commands/mobile/test/run.ts
@@ -1,0 +1,80 @@
+import { MobileClient } from "@autifyhq/autify-sdk";
+import { Command, Flags } from "@oclif/core";
+import emoji from "node-emoji";
+import { getMobileTestResultUrl } from "../../../autify/mobile/getTestResultUrl";
+import { runTest } from "../../../autify/mobile/runTest";
+import { get, getOrThrow } from "../../../config";
+import MobileTestWait from "./wait";
+
+export default class MobileTestRun extends Command {
+  static description = "Run a test plan.";
+
+  static examples = [
+    "Run a test plan:\n<%= config.bin %> <%= command.id %> https://mobile-app.autify.com/projects/AAA/test_plans/BBB ./my.app",
+    "Run and wait a test plan:\n<%= config.bin %> <%= command.id %> https://mobile-app.autify.com/projects/AAA/test_plans/BBB ./my.app --wait --timeout 600",
+  ];
+
+  static flags = {
+    wait: Flags.boolean({
+      char: "w",
+      description: "Wait until the test finishes.",
+      default: false,
+    }),
+    timeout: Flags.integer({
+      char: "t",
+      description:
+        "Timeout seconds when waiting for the finish of the test execution.",
+      default: 300,
+    }),
+    verbose: Flags.boolean({
+      char: "v",
+      description: "Verbose output",
+      default: false,
+    }),
+  };
+
+  static args = [
+    {
+      name: "test-plan-url",
+      description:
+        "Test plan URL e.g. https://mobile-app.autify.com/projects/<ID>/test_plans/<ID>",
+      required: true,
+    },
+    {
+      name: "build-path",
+      description: "File path to the iOS app (*.app) or Android app (*.apk).",
+      required: true,
+    },
+  ];
+
+  public async run(): Promise<void> {
+    const { args, flags } = await this.parse(MobileTestRun);
+    const { configDir, userAgent } = this.config;
+    const accessToken = getOrThrow(configDir, "AUTIFY_MOBILE_ACCESS_TOKEN");
+    const basePath = get(configDir, "AUTIFY_MOBILE_BASE_PATH");
+    const client = new MobileClient(accessToken, { basePath, userAgent });
+    const { workspaceId, resultId } = await runTest(
+      client,
+      args["test-plan-url"],
+      args["build-path"]
+    );
+    const testResultUrl = getMobileTestResultUrl(
+      configDir,
+      workspaceId,
+      resultId
+    );
+    this.log(
+      `${emoji.get("white_check_mark")} Successfully started: ${testResultUrl}`
+    );
+    if (flags.wait) {
+      const waitArgs = ["--timeout", flags.timeout.toString(), testResultUrl];
+      if (flags.verbose) waitArgs.push("--verbose");
+      await MobileTestWait.run(waitArgs);
+    } else {
+      this.log("To wait for the test result, run the command below:");
+      this.log(
+        `${emoji.get("computer")} $ autify mobile test wait ${testResultUrl}`
+      );
+    }
+  }
+}

--- a/src/commands/mobile/test/wait.ts
+++ b/src/commands/mobile/test/wait.ts
@@ -1,0 +1,75 @@
+import { MobileClient } from "@autifyhq/autify-sdk";
+import { Command, Flags } from "@oclif/core";
+import emoji from "node-emoji";
+import { getMobileTestResultUrl } from "../../../autify/mobile/getTestResultUrl";
+import { parseTestResultUrl } from "../../../autify/mobile/parseTestResultUrl";
+import { waitTestResult } from "../../../autify/mobile/waitTestResult";
+import { get, getOrThrow } from "../../../config";
+
+export default class MobileTestWait extends Command {
+  static description = "Wait a test result until it finishes.";
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %> https://mobile-app.autify.com/projects/AAA/results/BBB",
+  ];
+
+  static flags = {
+    timeout: Flags.integer({
+      char: "t",
+      description:
+        "Timeout seconds when waiting for the finish of the test execution.",
+      default: 300,
+    }),
+    verbose: Flags.boolean({
+      char: "v",
+      description: "Verbose output",
+      default: false,
+    }),
+  };
+
+  static args = [
+    {
+      name: "test-result-url",
+      description:
+        "Test result URL e.g. https://mobile-app.autify.com/projects/<ID>/results/<ID>",
+      required: true,
+    },
+  ];
+
+  public async run(): Promise<void> {
+    const { args, flags } = await this.parse(MobileTestWait);
+    const { configDir, userAgent } = this.config;
+    const accessToken = getOrThrow(configDir, "AUTIFY_MOBILE_ACCESS_TOKEN");
+    const basePath = get(configDir, "AUTIFY_MOBILE_BASE_PATH");
+    const client = new MobileClient(accessToken, { basePath, userAgent });
+    const { workspaceId, resultId } = parseTestResultUrl(
+      args["test-result-url"]
+    );
+    const testResultUrl = getMobileTestResultUrl(
+      configDir,
+      workspaceId,
+      resultId
+    );
+    this.log(
+      `${emoji.get("clock1")} Waiting for the test result: ${testResultUrl}`
+    );
+    const { isPassed, data } = await waitTestResult(
+      client,
+      workspaceId,
+      resultId,
+      { timeoutSecond: flags.timeout, verbose: flags.verbose }
+    );
+    if (isPassed) {
+      this.log(
+        `${emoji.get("white_check_mark")} Test passed!: ${testResultUrl}`
+      );
+      this.exit();
+    } else {
+      this.error(
+        `${emoji.get(
+          "x"
+        )} Test didn't pass. See ${testResultUrl}: ${JSON.stringify(data)}`
+      );
+    }
+  }
+}

--- a/test/commands/mobile/test/run.test.ts
+++ b/test/commands/mobile/test/run.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "@oclif/test";
+
+describe("mobile/test/run", () => {
+  test
+    .stdout()
+    .command(["mobile/test/run"])
+    .it("runs hello", (ctx) => {
+      expect(ctx.stdout).to.contain("hello world");
+    });
+
+  test
+    .stdout()
+    .command(["mobile/test/run", "--name", "jeff"])
+    .it("runs hello --name jeff", (ctx) => {
+      expect(ctx.stdout).to.contain("hello jeff");
+    });
+});

--- a/test/commands/mobile/test/wait.test.ts
+++ b/test/commands/mobile/test/wait.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "@oclif/test";
+
+describe("mobile/test/wait", () => {
+  test
+    .stdout()
+    .command(["mobile/test/wait"])
+    .it("runs hello", (ctx) => {
+      expect(ctx.stdout).to.contain("hello world");
+    });
+
+  test
+    .stdout()
+    .command(["mobile/test/wait", "--name", "jeff"])
+    .it("runs hello --name jeff", (ctx) => {
+      expect(ctx.stdout).to.contain("hello jeff");
+    });
+});


### PR DESCRIPTION
Just implementing `autify mobile test run/wait` by mostly copying from
`autify web test run/wait`. No integration test yet.

The biggest difference from `web` is uploading build file.
Only iOS app needs to be zipped so that we don't support Windows
and use `zip` command to make it easier.