### PR TITLE
Add `AUTIFY_TEST_WAIT_INTERVAL_SECOND`

### DIFF
--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -25,6 +25,7 @@
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",
+    "cross-env": "^7.0.3",
     "express": "^4.18.1",
     "http-proxy-middleware": "^2.0.6",
     "jest": "^28.1.3",
@@ -44,7 +45,7 @@
   "scripts": {
     "build": "shx rm -rf dist && tsc -b",
     "prepack": "npm run build",
-    "test": "jest dist/test",
+    "test": "cross-env AUTIFY_TEST_WAIT_INTERVAL_SECOND=0 jest dist/test",
     "test:record": "AUTIFY_POLLY_RECORD=1 jest dist/test --updateSnapshot"
   },
   "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "@pollyjs/adapter-node-http": "^6.0.5",
         "@pollyjs/core": "^6.0.5",
         "@pollyjs/persister-fs": "^6.0.5",
+        "cross-env": "^7.0.3",
         "express": "^4.18.1",
         "http-proxy-middleware": "^2.0.6",
         "jest": "^28.1.3",
@@ -3946,6 +3947,23 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -13220,6 +13238,7 @@
         "@types/jest": "^28.1.6",
         "@types/node": "^16.11.47",
         "@types/which": "^2.0.1",
+        "cross-env": "*",
         "express": "^4.18.1",
         "http-proxy-middleware": "^2.0.6",
         "jest": "^28.1.3",
@@ -16272,6 +16291,14 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/src/autify/getWaitIntervalSecond.ts
+++ b/src/autify/getWaitIntervalSecond.ts
@@ -1,0 +1,13 @@
+/* eslint-disable unicorn/filename-case */
+import { get } from "../config";
+
+const DEFAULT_INTERVAL_SECOND = 1;
+
+export const getWaitIntervalSecond = (configDir: string): number => {
+  const waitIntervalSecondString =
+    get(configDir, "AUTIFY_TEST_WAIT_INTERVAL_SECOND") ??
+    String(DEFAULT_INTERVAL_SECOND);
+  const waitIntervalSecond = Number.parseFloat(waitIntervalSecondString);
+  if (Number.isNaN(waitIntervalSecond)) return DEFAULT_INTERVAL_SECOND;
+  return waitIntervalSecond;
+};

--- a/src/autify/mobile/waitTestResult.ts
+++ b/src/autify/mobile/waitTestResult.ts
@@ -77,12 +77,12 @@ export const waitTestResult = async (
   client: MobileClient,
   workspaceId: string,
   resultId: string,
-  options: { timeoutSecond: number; verbose: boolean }
+  options: { timeoutSecond: number; verbose: boolean; intervalSecond: number }
 ): Promise<{ isPassed: boolean; data: any }> => {
   const data = await waitUntil(
     describeTestResult(client, workspaceId, resultId),
     options.timeoutSecond,
-    1,
+    options.intervalSecond,
     options.verbose
   );
   const isPassed = data?.status === "passed";

--- a/src/autify/web/waitTestResult.ts
+++ b/src/autify/web/waitTestResult.ts
@@ -81,12 +81,12 @@ export const waitTestResult = async (
   client: WebClient,
   workspaceId: number,
   resultId: number,
-  options: { timeoutSecond: number; verbose: boolean }
+  options: { timeoutSecond: number; verbose: boolean; intervalSecond: number }
 ): Promise<{ isPassed: boolean; data: any }> => {
   const data = await waitUntil(
     describeResult(client, workspaceId, resultId),
     options.timeoutSecond,
-    1,
+    options.intervalSecond,
     options.verbose
   );
   const isPassed = data?.status === "passed";

--- a/src/commands/mobile/test/wait.ts
+++ b/src/commands/mobile/test/wait.ts
@@ -1,6 +1,7 @@
 import { MobileClient } from "@autifyhq/autify-sdk";
 import { Command, Flags } from "@oclif/core";
 import emoji from "node-emoji";
+import { getWaitIntervalSecond } from "../../../autify/getWaitIntervalSecond";
 import { getMobileTestResultUrl } from "../../../autify/mobile/getTestResultUrl";
 import { parseTestResultUrl } from "../../../autify/mobile/parseTestResultUrl";
 import { waitTestResult } from "../../../autify/mobile/waitTestResult";
@@ -41,6 +42,7 @@ export default class MobileTestWait extends Command {
     const { configDir, userAgent } = this.config;
     const accessToken = getOrThrow(configDir, "AUTIFY_MOBILE_ACCESS_TOKEN");
     const basePath = get(configDir, "AUTIFY_MOBILE_BASE_PATH");
+    const waitIntervalSecond = getWaitIntervalSecond(configDir);
     const client = new MobileClient(accessToken, { basePath, userAgent });
     const { workspaceId, resultId } = parseTestResultUrl(
       args["test-result-url"]
@@ -57,7 +59,11 @@ export default class MobileTestWait extends Command {
       client,
       workspaceId,
       resultId,
-      { timeoutSecond: flags.timeout, verbose: flags.verbose }
+      {
+        timeoutSecond: flags.timeout,
+        verbose: flags.verbose,
+        intervalSecond: waitIntervalSecond,
+      }
     );
     if (isPassed) {
       this.log(

--- a/src/commands/web/test/wait.ts
+++ b/src/commands/web/test/wait.ts
@@ -5,6 +5,7 @@ import { get, getOrThrow } from "../../../config";
 import { parseTestResultUrl } from "../../../autify/web/parseTestResultUrl";
 import { waitTestResult } from "../../../autify/web/waitTestResult";
 import { getWebTestResultUrl } from "../../../autify/web/getTestResultUrl";
+import { getWaitIntervalSecond } from "../../../autify/getWaitIntervalSecond";
 
 export default class WebTestWait extends Command {
   static description = "Wait a test result until it finishes.";
@@ -41,6 +42,7 @@ export default class WebTestWait extends Command {
     const { configDir, userAgent } = this.config;
     const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
     const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
+    const waitIntervalSecond = getWaitIntervalSecond(configDir);
     const client = new WebClient(accessToken, { basePath, userAgent });
     const { workspaceId, resultId } = parseTestResultUrl(
       args["test-result-url"]
@@ -53,7 +55,11 @@ export default class WebTestWait extends Command {
       client,
       workspaceId,
       resultId,
-      { timeoutSecond: flags.timeout, verbose: flags.verbose }
+      {
+        timeoutSecond: flags.timeout,
+        verbose: flags.verbose,
+        intervalSecond: waitIntervalSecond,
+      }
     );
     if (isPassed) {
       this.log(

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,8 @@ type Variable =
   | "AUTIFY_WEB_ACCESS_TOKEN"
   | "AUTIFY_WEB_BASE_PATH"
   | "AUTIFY_MOBILE_ACCESS_TOKEN"
-  | "AUTIFY_MOBILE_BASE_PATH";
+  | "AUTIFY_MOBILE_BASE_PATH"
+  | "AUTIFY_TEST_WAIT_INTERVAL_SECOND";
 
 const envFile = (dir: string) => path.resolve(dir, "config.env");
 const read = (dir: string) =>


### PR DESCRIPTION
For integration tests, we don't have to wait 1 second interval
while waiting the test result.

`AUTIFY_TEST_WAIT_INTERVAL_SECOND` config can override the interval
and speed up the integration test executions.