### PR TITLE
Add `--autify-connect-key` to `web test run`

### DIFF
--- a/src/autify/web/runTest.ts
+++ b/src/autify/web/runTest.ts
@@ -87,12 +87,13 @@ type RunTestProps = Readonly<{
   option: CapabilityOption;
   name?: string;
   urlReplacements: CreateUrlReplacementRequest[];
+  autifyConnectKey?: string;
 }>;
 
 export const runTest = async (
   client: WebClient,
   url: string,
-  { option, name, urlReplacements }: RunTestProps
+  { option, name, urlReplacements, autifyConnectKey }: RunTestProps
 ): Promise<{ workspaceId: number; resultId: number; capability: string }> => {
   const scenario = parseScenarioUrl(url);
   const testPlan = parseTestPlanUrl(url);
@@ -105,6 +106,12 @@ export const runTest = async (
       scenarios: [{ id: scenarioId }],
       // eslint-disable-next-line camelcase
       url_replacements: urlReplacements,
+      ...(autifyConnectKey && {
+        // eslint-disable-next-line camelcase
+        autify_connect: {
+          name: autifyConnectKey,
+        },
+      }),
     });
     return {
       workspaceId,
@@ -122,6 +129,10 @@ export const runTest = async (
       );
     if (name)
       throw new CLIError(`Running TestPlan doesn't support --name: ${name}`);
+    if (autifyConnectKey)
+      throw new CLIError(
+        `Running TestPlan doesn't support --autify-connect-key: ${autifyConnectKey}`
+      );
     const { workspaceId, testPlanId } = testPlan;
     const urlReplacementIds = [];
     for await (const urlReplacement of urlReplacements ?? []) {

--- a/src/commands/web/test/run.ts
+++ b/src/commands/web/test/run.ts
@@ -36,6 +36,7 @@ export default class WebTestRun extends Command {
     'Run a test scenario with a specific capability:\n<%= config.bin %> <%= command.id %> https://app.autify.com/projects/0000/scenarios/0000 --os "Windows Server" --browser Edge',
     "With URL replacements:\n<%= config.bin %> <%= command.id %> https://app.autify.com/projects/0000/scenarios/0000 -r http://example.com=http://example.net -r http://example.org=http://example.net",
     'Run a test with specifying the execution name:\n<%= config.bin %> <%= command.id %> https://app.autify.com/projects/0000/scenarios/0000 --name "Sample execution"',
+    "Run a test scenario with Autify Connect:\n<%= config.bin %> <%= command.id %> https://app.autify.com/projects/0000/scenarios/0000 --autify-connect-key KEY_NAME",
   ];
 
   static flags = {
@@ -49,6 +50,10 @@ export default class WebTestRun extends Command {
       description:
         "URL replacements. Example: http://example.com=http://example.net",
       multiple: true,
+    }),
+    "autify-connect-key": Flags.string({
+      description:
+        "Name of the Autify Connect Key (Only for test scenario execution.)",
     }),
     os: Flags.string({ description: "OS to run the test" }),
     "os-version": Flags.string({ description: "OS version to run the test" }),
@@ -102,6 +107,7 @@ export default class WebTestRun extends Command {
           urlReplacements
         )}`
       );
+    const autifyConnectKey = flags["autify-connect-key"];
     const { configDir, userAgent } = this.config;
     const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
     const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
@@ -113,6 +119,7 @@ export default class WebTestRun extends Command {
         option: capabilityOption,
         name: flags.name,
         urlReplacements,
+        autifyConnectKey,
       }
     );
     const testResultUrl = getWebTestResultUrl(configDir, workspaceId, resultId);


### PR DESCRIPTION
Since `executeScenario` API supports overriding Autify Connect Key,
we'd like to support it via `autify web test run` as well.

Until test plan execution supports the same overriding,
this option is only valid for test scenario executions.