### PR TITLE
Run `generate-fake-app` before running `jest`

### DIFF
--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -45,7 +45,8 @@
   "scripts": {
     "build": "shx rm -rf dist && tsc -b",
     "prepack": "npm run build",
-    "test": "cross-env AUTIFY_TEST_WAIT_INTERVAL_SECOND=0 jest dist/test",
+    "generate-fake-app": "node dist/test/helpers/generateFakeApp.js",
+    "test": "npm run generate-fake-app && cross-env AUTIFY_TEST_WAIT_INTERVAL_SECOND=0 jest dist/test",
     "test:record": "AUTIFY_POLLY_RECORD=1 jest dist/test --updateSnapshot"
   },
   "engines": {

--- a/integration-test/src/test/helpers/generateFakeApp.ts
+++ b/integration-test/src/test/helpers/generateFakeApp.ts
@@ -1,0 +1,25 @@
+/* eslint-disable unicorn/filename-case */
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { androidBuildPath, iosBuildPath } from "./testAutifyCliSnapshot";
+
+// https://commons.wikimedia.org/wiki/File:Transparent.gif
+const tinyBinary = Buffer.from(
+  "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+  "base64"
+);
+
+// Generate fake build files if not exiting.
+// For recording, you should setup the real files on the same paths.
+if (existsSync(iosBuildPath)) {
+  console.log(`${iosBuildPath} already exists.`);
+} else {
+  mkdirSync(iosBuildPath); // *.app is a directory
+  writeFileSync(join(iosBuildPath, "ios"), tinyBinary); // Add a fake binary file
+}
+
+if (existsSync(androidBuildPath)) {
+  console.log(`${androidBuildPath} already exists.`);
+} else {
+  writeFileSync(androidBuildPath, tinyBinary); // Create a fake binary file
+}

--- a/integration-test/src/test/helpers/testAutifyCliSnapshot.ts
+++ b/integration-test/src/test/helpers/testAutifyCliSnapshot.ts
@@ -1,25 +1,8 @@
 /* eslint-disable unicorn/filename-case */
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
 import { execAutifyCli } from "../helpers/execAutifyCli";
 
-const iosBuildPath = "ios.app";
-const androidBuildPath = "android.apk";
-// https://commons.wikimedia.org/wiki/File:Transparent.gif
-const tinyBinary = Buffer.from(
-  "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
-  "base64"
-);
-// Generate fake build files if not exiting.
-// For recording, you should setup the real files on the same paths.
-if (!existsSync(iosBuildPath)) {
-  mkdirSync(iosBuildPath); // *.app is a directory
-  writeFileSync(join(iosBuildPath, "ios"), tinyBinary); // Add a fake binary file
-}
-
-if (!existsSync(androidBuildPath)) {
-  writeFileSync(androidBuildPath, tinyBinary); // Create a fake binary file
-}
+export const iosBuildPath = "ios.app";
+export const androidBuildPath = "android.apk";
 
 export const webTestRun =
   "web test run https://app.autify.com/projects/743/scenarios/91437";


### PR DESCRIPTION
Since the current code has a tiny race condition when creating fake apps
because `jest` runs multiple test files in parallel.

This commit introduces a new npm task to generate fake apps and
run it before running `jest` so that we can ensure that this process
runs only once.