### PR TITLE
Rename to `--autify-connect`

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ Run a scenario or test plan.
 
 ```
 USAGE
-  $ autify web test run [SCENARIO-OR-TEST-PLAN-URL] [-n <value>] [-r <value>] [--autify-connect-key <value>] [--os
+  $ autify web test run [SCENARIO-OR-TEST-PLAN-URL] [-n <value>] [-r <value>] [--autify-connect <value>] [--os
     <value>] [--os-version <value>] [--browser <value>] [--device <value>] [--device-type <value>] [-w] [-t <value>]
     [-v]
 
@@ -593,7 +593,7 @@ FLAGS
   -t, --timeout=<value>              [default: 300] Timeout seconds when waiting for the finish of the test execution.
   -v, --verbose                      Verbose output
   -w, --wait                         Wait until the test finishes.
-  --autify-connect-key=<value>       Name of the Autify Connect Key (Only for test scenario execution.)
+  --autify-connect=<value>           Name of the Autify Connect Access Point (Only for test scenario execution.)
   --browser=<value>                  Browser to run the test
   --device=<value>                   Device to run the test
   --device-type=<value>              Device type to run the test
@@ -631,7 +631,7 @@ EXAMPLES
 
   Run a test scenario with Autify Connect:
 
-    $ autify web test run https://app.autify.com/projects/0000/scenarios/0000 --autify-connect-key KEY_NAME
+    $ autify web test run https://app.autify.com/projects/0000/scenarios/0000 --autify-connect NAME
 ```
 
 ## `autify web test wait TEST-RESULT-URL`

--- a/src/autify/web/runTest.ts
+++ b/src/autify/web/runTest.ts
@@ -87,13 +87,13 @@ type RunTestProps = Readonly<{
   option: CapabilityOption;
   name?: string;
   urlReplacements: CreateUrlReplacementRequest[];
-  autifyConnectKey?: string;
+  autifyConnect?: string;
 }>;
 
 export const runTest = async (
   client: WebClient,
   url: string,
-  { option, name, urlReplacements, autifyConnectKey }: RunTestProps
+  { option, name, urlReplacements, autifyConnect }: RunTestProps
 ): Promise<{ workspaceId: number; resultId: number; capability: string }> => {
   const scenario = parseScenarioUrl(url);
   const testPlan = parseTestPlanUrl(url);
@@ -106,10 +106,10 @@ export const runTest = async (
       scenarios: [{ id: scenarioId }],
       // eslint-disable-next-line camelcase
       url_replacements: urlReplacements,
-      ...(autifyConnectKey && {
+      ...(autifyConnect && {
         // eslint-disable-next-line camelcase
         autify_connect: {
-          name: autifyConnectKey,
+          name: autifyConnect,
         },
       }),
     });
@@ -129,9 +129,9 @@ export const runTest = async (
       );
     if (name)
       throw new CLIError(`Running TestPlan doesn't support --name: ${name}`);
-    if (autifyConnectKey)
+    if (autifyConnect)
       throw new CLIError(
-        `Running TestPlan doesn't support --autify-connect-key: ${autifyConnectKey}`
+        `Running TestPlan doesn't support --autify-connect-key: ${autifyConnect}`
       );
     const { workspaceId, testPlanId } = testPlan;
     const urlReplacementIds = [];

--- a/src/commands/web/test/run.ts
+++ b/src/commands/web/test/run.ts
@@ -36,7 +36,7 @@ export default class WebTestRun extends Command {
     'Run a test scenario with a specific capability:\n<%= config.bin %> <%= command.id %> https://app.autify.com/projects/0000/scenarios/0000 --os "Windows Server" --browser Edge',
     "With URL replacements:\n<%= config.bin %> <%= command.id %> https://app.autify.com/projects/0000/scenarios/0000 -r http://example.com=http://example.net -r http://example.org=http://example.net",
     'Run a test with specifying the execution name:\n<%= config.bin %> <%= command.id %> https://app.autify.com/projects/0000/scenarios/0000 --name "Sample execution"',
-    "Run a test scenario with Autify Connect:\n<%= config.bin %> <%= command.id %> https://app.autify.com/projects/0000/scenarios/0000 --autify-connect-key KEY_NAME",
+    "Run a test scenario with Autify Connect:\n<%= config.bin %> <%= command.id %> https://app.autify.com/projects/0000/scenarios/0000 --autify-connect NAME",
   ];
 
   static flags = {
@@ -51,9 +51,9 @@ export default class WebTestRun extends Command {
         "URL replacements. Example: http://example.com=http://example.net",
       multiple: true,
     }),
-    "autify-connect-key": Flags.string({
+    "autify-connect": Flags.string({
       description:
-        "Name of the Autify Connect Key (Only for test scenario execution.)",
+        "Name of the Autify Connect Access Point (Only for test scenario execution.)",
     }),
     os: Flags.string({ description: "OS to run the test" }),
     "os-version": Flags.string({ description: "OS version to run the test" }),
@@ -107,7 +107,7 @@ export default class WebTestRun extends Command {
           urlReplacements
         )}`
       );
-    const autifyConnectKey = flags["autify-connect-key"];
+    const autifyConnect = flags["autify-connect"];
     const { configDir, userAgent } = this.config;
     const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
     const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
@@ -119,7 +119,7 @@ export default class WebTestRun extends Command {
         option: capabilityOption,
         name: flags.name,
         urlReplacements,
-        autifyConnectKey,
+        autifyConnect,
       }
     );
     const testResultUrl = getWebTestResultUrl(configDir, workspaceId, resultId);


### PR DESCRIPTION
Since we're going to rename some terminologies,
`--autify-connect` is more suitable than `--autify-connect-key`.

We're going to just rename it and break backward compatibility
but it's fine since we've just released the previous version
and Autify Connect is an optional feature as of today.

See https://github.com/autifyhq/autify-cli/pull/72