### PR TITLE
Add `connect` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ npm install -g @autifyhq/autify-cli
 $ autify COMMAND
 running command...
 $ autify (--version)
-@autifyhq/autify-cli/0.8.0-beta.0 linux-x64 node-v16.17.0
+@autifyhq/autify-cli/0.8.0-beta.0 linux-x64 node-v16.14.0
 $ autify --help [COMMAND]
 USAGE
   $ autify COMMAND
@@ -60,6 +60,8 @@ After the installation, you can always get the latest update on `stable` channel
 
 <!-- commands -->
 
+- [`autify connect access-point set`](#autify-connect-access-point-set)
+- [`autify connect client start`](#autify-connect-client-start)
 - [`autify help [COMMAND]`](#autify-help-command)
 - [`autify mobile api describe-test-result`](#autify-mobile-api-describe-test-result)
 - [`autify mobile api list-test-results`](#autify-mobile-api-list-test-results)
@@ -84,6 +86,49 @@ After the installation, you can always get the latest update on `stable` channel
 - [`autify web auth login`](#autify-web-auth-login)
 - [`autify web test run SCENARIO-OR-TEST-PLAN-URL`](#autify-web-test-run-scenario-or-test-plan-url)
 - [`autify web test wait TEST-RESULT-URL`](#autify-web-test-wait-test-result-url)
+
+## `autify connect access-point set`
+
+Set Autify Connect Access Point
+
+```
+USAGE
+  $ autify connect access-point set --name <value>
+
+FLAGS
+  --name=<value>  (required) Name of the Autify Connect Access Point already created
+
+DESCRIPTION
+  Set Autify Connect Access Point
+
+EXAMPLES
+  Start interactive setup:
+
+    $ autify connect access-point set --name=NAME
+
+  Reading the key from file:
+
+    $ autify connect access-point set --name=NAME < key.txt
+```
+
+## `autify connect client start`
+
+Start Autify Connect Client
+
+```
+USAGE
+  $ autify connect client start [--client-args-override <value>]
+
+FLAGS
+  --client-args-override=<value>  Command line argument to override when starting Autify Connect Client e.g. "--verbose
+                                  --log-format json"
+
+DESCRIPTION
+  Start Autify Connect Client
+
+EXAMPLES
+  $ autify connect client start
+```
 
 ## `autify help [COMMAND]`
 
@@ -579,9 +624,9 @@ Run a scenario or test plan.
 
 ```
 USAGE
-  $ autify web test run [SCENARIO-OR-TEST-PLAN-URL] [-n <value>] [-r <value>] [--autify-connect <value>] [--os
-    <value>] [--os-version <value>] [--browser <value>] [--device <value>] [--device-type <value>] [-w] [-t <value>]
-    [-v]
+  $ autify web test run [SCENARIO-OR-TEST-PLAN-URL] [-n <value>] [-r <value>] [--autify-connect <value> |
+    --autify-connect-client] [--os <value>] [--os-version <value>] [--browser <value>] [--device <value>] [--device-type
+    <value>] [-w] [-t <value>] [-v]
 
 ARGUMENTS
   SCENARIO-OR-TEST-PLAN-URL  Scenario URL or Test plan URL e.g.
@@ -594,6 +639,7 @@ FLAGS
   -v, --verbose                      Verbose output
   -w, --wait                         Wait until the test finishes.
   --autify-connect=<value>           Name of the Autify Connect Access Point (Only for test scenario execution.)
+  --autify-connect-client            Start Autify Connect Client (Only for test scenario execution.)
   --browser=<value>                  Browser to run the test
   --device=<value>                   Device to run the test
   --device-type=<value>              Device type to run the test

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,9 +24,12 @@
         "inquirer": "^8.2.4",
         "listr": "^0.14.3",
         "node-emoji": "^1.11.0",
+        "node-fetch": "^2.6.7",
         "per-env": "^1.0.2",
+        "shell-quote": "^1.7.3",
         "tempy": "^3.0.0",
         "tsimportlib": "^0.0.3",
+        "unzip-stream": "^0.3.1",
         "which": "^2.0.2"
       },
       "bin": {
@@ -41,6 +44,9 @@
         "@types/mocha": "^9.1.1",
         "@types/node": "^16.11.52",
         "@types/node-emoji": "^1.8.1",
+        "@types/node-fetch": "^2.6.2",
+        "@types/shell-quote": "^1.7.1",
+        "@types/unzip-stream": "^0.3.1",
         "chai": "^4",
         "eslint": "^7.32.0",
         "eslint-config-oclif": "^4",
@@ -2184,6 +2190,30 @@
       "integrity": "sha512-0fRfA90FWm6KJfw6P9QGyo0HDTCmthZ7cWaBQndITlaWLTZ6njRyKwrwpzpg+n6kBXBIGKeUHEQuBx7bphGJkA==",
       "dev": true
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -2225,6 +2255,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/shell-quote": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.7.1.tgz",
+      "integrity": "sha512-SWZ2Nom1pkyXCDohRSrkSKvDh8QOG9RfAsrt5/NsPQC4UQJ55eG0qClA40I+Gkez4KTQ0uDUT8ELRXThf3J5jw==",
+      "dev": true
+    },
     "node_modules/@types/sinon": {
       "version": "10.0.11",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.11.tgz",
@@ -2249,6 +2285,15 @@
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
       "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/unzip-stream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@types/unzip-stream/-/unzip-stream-0.3.1.tgz",
+      "integrity": "sha512-RlE3qaqvu4XaMwxkG/zR1gIunCbqXvNrmZ4BCG7OiQ8QUactFUPxm0TTrOCRJZQfPW3T6XBH7PcHQiiqkdcijw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -2962,6 +3007,18 @@
         "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -3162,6 +3219,14 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "engines": {
+        "node": ">=0.2.0"
+      }
+    },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
@@ -3323,6 +3388,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chalk": {
@@ -4281,7 +4357,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -4291,7 +4366,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -8304,8 +8378,7 @@
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minipass": {
       "version": "3.1.6",
@@ -8734,7 +8807,6 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -11309,8 +11381,7 @@
     "node_modules/shell-quote": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true
+      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="
     },
     "node_modules/shelljs": {
       "version": "0.8.5",
@@ -12060,8 +12131,15 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -12322,6 +12400,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/unzip-stream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/unzip-stream/-/unzip-stream-0.3.1.tgz",
+      "integrity": "sha512-RzaGXLNt+CW+T41h1zl6pGz3EaeVhYlK+rdAap+7DxW5kqsqePO8kRtWPaCiVqdhZc86EctSPVYNix30YOMzmw==",
+      "dependencies": {
+        "binary": "^0.3.0",
+        "mkdirp": "^0.5.1"
+      }
+    },
+    "node_modules/unzip-stream/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -12502,14 +12600,12 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "dev": true
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -14977,6 +15073,29 @@
       "integrity": "sha512-0fRfA90FWm6KJfw6P9QGyo0HDTCmthZ7cWaBQndITlaWLTZ6njRyKwrwpzpg+n6kBXBIGKeUHEQuBx7bphGJkA==",
       "dev": true
     },
+    "@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -15018,6 +15137,12 @@
         "@types/node": "*"
       }
     },
+    "@types/shell-quote": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.7.1.tgz",
+      "integrity": "sha512-SWZ2Nom1pkyXCDohRSrkSKvDh8QOG9RfAsrt5/NsPQC4UQJ55eG0qClA40I+Gkez4KTQ0uDUT8ELRXThf3J5jw==",
+      "dev": true
+    },
     "@types/sinon": {
       "version": "10.0.11",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.11.tgz",
@@ -15042,6 +15167,15 @@
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
       "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/unzip-stream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@types/unzip-stream/-/unzip-stream-0.3.1.tgz",
+      "integrity": "sha512-RlE3qaqvu4XaMwxkG/zR1gIunCbqXvNrmZ4BCG7OiQ8QUactFUPxm0TTrOCRJZQfPW3T6XBH7PcHQiiqkdcijw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -15555,6 +15689,15 @@
         }
       }
     },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "requires": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      }
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -15704,6 +15847,11 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ=="
+    },
     "builtin-modules": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
@@ -15815,6 +15963,14 @@
         "loupe": "^2.3.1",
         "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
+      }
+    },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "requires": {
+        "traverse": ">=0.3.0 <0.4"
       }
     },
     "chalk": {
@@ -16525,7 +16681,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "optional": true,
       "requires": {
         "iconv-lite": "^0.6.2"
@@ -16535,7 +16690,6 @@
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "dev": true,
           "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -19499,8 +19653,7 @@
     "minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minipass": {
       "version": "3.1.6",
@@ -19835,7 +19988,6 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -21780,8 +21932,7 @@
     "shell-quote": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true
+      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="
     },
     "shelljs": {
       "version": "0.8.5",
@@ -22331,8 +22482,12 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ=="
     },
     "tree-kill": {
       "version": "1.2.2",
@@ -22517,6 +22672,25 @@
       "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
       "dev": true
     },
+    "unzip-stream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/unzip-stream/-/unzip-stream-0.3.1.tgz",
+      "integrity": "sha512-RzaGXLNt+CW+T41h1zl6pGz3EaeVhYlK+rdAap+7DxW5kqsqePO8kRtWPaCiVqdhZc86EctSPVYNix30YOMzmw==",
+      "requires": {
+        "binary": "^0.3.0",
+        "mkdirp": "^0.5.1"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+          "requires": {
+            "minimist": "^1.2.6"
+          }
+        }
+      }
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -22680,14 +22854,12 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "dev": true
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -28,9 +28,12 @@
     "inquirer": "^8.2.4",
     "listr": "^0.14.3",
     "node-emoji": "^1.11.0",
+    "node-fetch": "^2.6.7",
     "per-env": "^1.0.2",
+    "shell-quote": "^1.7.3",
     "tempy": "^3.0.0",
     "tsimportlib": "^0.0.3",
+    "unzip-stream": "^0.3.1",
     "which": "^2.0.2"
   },
   "devDependencies": {
@@ -42,6 +45,9 @@
     "@types/mocha": "^9.1.1",
     "@types/node": "^16.11.52",
     "@types/node-emoji": "^1.8.1",
+    "@types/node-fetch": "^2.6.2",
+    "@types/shell-quote": "^1.7.1",
+    "@types/unzip-stream": "^0.3.1",
     "chai": "^4",
     "eslint": "^7.32.0",
     "eslint-config-oclif": "^4",

--- a/src/autify/connect/installClient.ts
+++ b/src/autify/connect/installClient.ts
@@ -1,0 +1,78 @@
+/* eslint-disable unicorn/filename-case */
+import { CLIError } from "@oclif/errors";
+import { arch, platform } from "node:process";
+import fetch from "node-fetch";
+import { createReadStream, createWriteStream, existsSync } from "node:fs";
+import { pipeline } from "node:stream";
+import { promisify } from "node:util";
+import { basename, dirname, join } from "node:path";
+import { execSync } from "node:child_process";
+import { Extract } from "unzip-stream";
+
+const getOs = () => {
+  const os = platform;
+  if (os === "linux") return "linux";
+  if (os === "darwin") return "darwin";
+  if (os === "win32") return "windows";
+  throw new CLIError(`Unsupported OS: ${os}`);
+};
+
+const getArch = () => {
+  if (arch === "ia32") return "386";
+  if (arch === "x64") return "amd64";
+  if (arch === "arm64") return "arm64";
+  throw new CLIError(`Unsupported Architecture: ${arch}`);
+};
+
+const getExt = () => (getOs() === "windows" ? "zip" : "tar.gz");
+
+const baseUrl =
+  "https://autifyconnect.s3.ap-northeast-1.amazonaws.com/autifyconnect/versions/stable";
+const getUrl = () => {
+  const os = getOs();
+  const arch = getArch();
+  const ext = getExt();
+  return new URL(`${baseUrl}/autifyconnect_${os}_${arch}.${ext}`);
+};
+
+const download = async (cacheDir: string) => {
+  const url = getUrl();
+  const downloadPath = join(cacheDir, basename(url.pathname));
+  const response = await fetch(url);
+  if (!response.ok)
+    throw new CLIError(`Failed to fetch ${url}: ${response.status}`);
+  const streamPipeline = promisify(pipeline);
+  await streamPipeline(response.body, createWriteStream(downloadPath));
+  return downloadPath;
+};
+
+const extract = async (downloadPath: string) => {
+  const file = basename(downloadPath);
+  const dir = dirname(downloadPath);
+  if (file.endsWith(".tar.gz")) {
+    const command = `tar xvzf ${file}`;
+    execSync(command, { cwd: dir });
+  }
+
+  if (file.endsWith(".zip")) {
+    const streamPipeline = promisify(pipeline);
+    await streamPipeline(
+      createReadStream(downloadPath),
+      // eslint-disable-next-line new-cap
+      Extract({ path: dir })
+    );
+  }
+};
+
+const getClientPath = (cacheDir: string) =>
+  getOs() === "windows"
+    ? join(cacheDir, "autifyconnect.exe")
+    : join(cacheDir, "autifyconnect");
+
+export const installClient = async (cacheDir: string): Promise<string> => {
+  const clientPath = getClientPath(cacheDir);
+  if (existsSync(clientPath)) return clientPath;
+  const downloadPath = await download(cacheDir);
+  await extract(downloadPath);
+  return clientPath;
+};

--- a/src/autify/connect/spawnClient.ts
+++ b/src/autify/connect/spawnClient.ts
@@ -1,0 +1,86 @@
+/* eslint-disable unicorn/filename-case */
+import { CLIError } from "@oclif/errors";
+import {
+  ChildProcess,
+  execSync,
+  spawn,
+  StdioOptions,
+} from "node:child_process";
+import { parse } from "shell-quote";
+import { constants } from "node:os";
+import { get } from "../../config";
+import { installClient } from "./installClient";
+
+const parseClientArgs = (str: string): string[] =>
+  parse(str).filter((a): a is string => typeof a === "string");
+
+export type AutifyConnectClient = Readonly<{
+  childProcess: ChildProcess;
+  accessPoint: string;
+  waitExit: () => Promise<number>;
+}>;
+
+type SpawnClientOptions = Readonly<{
+  clientArgs?: string;
+  stdio?: StdioOptions;
+  exitOnSignal?: boolean;
+  killBeforeWaitExit?: boolean;
+}>;
+
+const validateClient = (clientPath: string) => {
+  try {
+    execSync(`${clientPath} --version`, { stdio: "ignore" });
+  } catch (error) {
+    throw new CLIError(
+      `Autify Connect Client failed to exec. (path: ${clientPath}, error: ${error})`
+    );
+  }
+};
+
+export const spawnClient = async (
+  configDir: string,
+  cacheDir: string,
+  {
+    clientArgs = "",
+    stdio = "inherit",
+    exitOnSignal = false,
+    killBeforeWaitExit = false,
+  }: SpawnClientOptions
+): Promise<AutifyConnectClient> => {
+  const clientPath = await installClient(cacheDir);
+  validateClient(clientPath);
+  const accessPoint = get(configDir, "AUTIFY_CONNECT_ACCESS_POINT_NAME");
+  const key = get(configDir, "AUTIFY_CONNECT_ACCESS_POINT_KEY");
+  if (!accessPoint || !key)
+    throw new CLIError(
+      "Autify Connect Access Point must be set. Use `autify connect access-point set` first."
+    );
+  const childProcess = spawn(clientPath, parseClientArgs(clientArgs), {
+    env: {
+      AUTIFY_CONNECT_KEY: key,
+    },
+    stdio,
+  });
+  const exitBySignalHandler = (signal: NodeJS.Signals) => {
+    if (exitOnSignal)
+      childProcess.on("exit", () =>
+        // eslint-disable-next-line no-process-exit, unicorn/no-process-exit
+        process.exit(128 + constants.signals[signal])
+      );
+    childProcess.kill(signal);
+  };
+
+  process.on("SIGINT", exitBySignalHandler);
+  process.on("SIGTERM", exitBySignalHandler);
+  return {
+    childProcess,
+    accessPoint,
+    waitExit: () => {
+      return new Promise((resolve, reject) => {
+        childProcess.on("exit", (code) => resolve(code ?? 1));
+        childProcess.on("error", (error) => reject(error));
+        if (killBeforeWaitExit) childProcess.kill();
+      });
+    },
+  };
+};

--- a/src/autify/web/runTest.ts
+++ b/src/autify/web/runTest.ts
@@ -87,13 +87,13 @@ type RunTestProps = Readonly<{
   option: CapabilityOption;
   name?: string;
   urlReplacements: CreateUrlReplacementRequest[];
-  autifyConnect?: string;
+  autifyConnectAccessPoint?: string;
 }>;
 
 export const runTest = async (
   client: WebClient,
   url: string,
-  { option, name, urlReplacements, autifyConnect }: RunTestProps
+  { option, name, urlReplacements, autifyConnectAccessPoint }: RunTestProps
 ): Promise<{ workspaceId: number; resultId: number; capability: string }> => {
   const scenario = parseScenarioUrl(url);
   const testPlan = parseTestPlanUrl(url);
@@ -106,10 +106,10 @@ export const runTest = async (
       scenarios: [{ id: scenarioId }],
       // eslint-disable-next-line camelcase
       url_replacements: urlReplacements,
-      ...(autifyConnect && {
+      ...(autifyConnectAccessPoint && {
         // eslint-disable-next-line camelcase
         autify_connect: {
-          name: autifyConnect,
+          name: autifyConnectAccessPoint,
         },
       }),
     });
@@ -129,9 +129,9 @@ export const runTest = async (
       );
     if (name)
       throw new CLIError(`Running TestPlan doesn't support --name: ${name}`);
-    if (autifyConnect)
+    if (autifyConnectAccessPoint)
       throw new CLIError(
-        `Running TestPlan doesn't support --autify-connect-key: ${autifyConnect}`
+        "Running TestPlan doesn't support Autify Connect Access Point"
       );
     const { workspaceId, testPlanId } = testPlan;
     const urlReplacementIds = [];

--- a/src/commands/connect/access-point/set.ts
+++ b/src/commands/connect/access-point/set.ts
@@ -1,0 +1,38 @@
+import { Command, Flags } from "@oclif/core";
+import * as inquirer from "inquirer";
+import { set } from "../../../config";
+
+export default class ConnectAccessPointSet extends Command {
+  static description = "Set Autify Connect Access Point";
+
+  static examples = [
+    "Start interactive setup:\n<%= config.bin %> <%= command.id %> --name=NAME",
+    "Reading the key from file:\n<%= config.bin %> <%= command.id %> --name=NAME < key.txt",
+  ];
+
+  static flags = {
+    name: Flags.string({
+      description: "Name of the Autify Connect Access Point already created",
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(ConnectAccessPointSet);
+    const key = await this.readKeyFromStdin();
+    set(this.config.configDir, "AUTIFY_CONNECT_ACCESS_POINT_NAME", flags.name);
+    set(this.config.configDir, "AUTIFY_CONNECT_ACCESS_POINT_KEY", key);
+  }
+
+  private async readKeyFromStdin() {
+    const res = await inquirer.prompt([
+      {
+        name: "key",
+        message: "Enter Autify Connect Access Point Key",
+        type: "password",
+        mask: true,
+      },
+    ]);
+    return res.key as string;
+  }
+}

--- a/src/commands/connect/client/start.ts
+++ b/src/commands/connect/client/start.ts
@@ -1,0 +1,29 @@
+import { Command, Flags } from "@oclif/core";
+import { spawnClient } from "../../../autify/connect/spawnClient";
+
+export default class ConnectClientStart extends Command {
+  static description = "Start Autify Connect Client";
+
+  static examples = ["<%= config.bin %> <%= command.id %>"];
+
+  static flags = {
+    "client-args-override": Flags.string({
+      description:
+        'Command line argument to override when starting Autify Connect Client e.g. "--verbose --log-format json"',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(ConnectClientStart);
+    const { configDir, cacheDir } = this.config;
+    const clientArgs = flags["client-args-override"];
+    const { accessPoint, waitExit } = await spawnClient(configDir, cacheDir, {
+      clientArgs,
+    });
+    this.log(
+      `Starting Autify Connect Client for Access Point "${accessPoint}"...`
+    );
+    const code = await waitExit();
+    this.exit(code);
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,8 @@ type Variable =
   | "AUTIFY_WEB_BASE_PATH"
   | "AUTIFY_MOBILE_ACCESS_TOKEN"
   | "AUTIFY_MOBILE_BASE_PATH"
+  | "AUTIFY_CONNECT_ACCESS_POINT_NAME"
+  | "AUTIFY_CONNECT_ACCESS_POINT_KEY"
   | "AUTIFY_TEST_WAIT_INTERVAL_SECOND";
 
 const envFile = (dir: string) => path.resolve(dir, "config.env");

--- a/test/commands/connect/access-point/set.test.ts
+++ b/test/commands/connect/access-point/set.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "@oclif/test";
+
+describe("connect/access-point/set", () => {
+  test
+    .stdout()
+    .command(["connect/access-point/set"])
+    .it("runs hello", (ctx) => {
+      expect(ctx.stdout).to.contain("hello world");
+    });
+
+  test
+    .stdout()
+    .command(["connect/access-point/set", "--name", "jeff"])
+    .it("runs hello --name jeff", (ctx) => {
+      expect(ctx.stdout).to.contain("hello jeff");
+    });
+});

--- a/test/commands/connect/client/start.test.ts
+++ b/test/commands/connect/client/start.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "@oclif/test";
+
+describe("connect/client/start", () => {
+  test
+    .stdout()
+    .command(["connect/client/start"])
+    .it("runs hello", (ctx) => {
+      expect(ctx.stdout).to.contain("hello world");
+    });
+
+  test
+    .stdout()
+    .command(["connect/client/start", "--name", "jeff"])
+    .it("runs hello --name jeff", (ctx) => {
+      expect(ctx.stdout).to.contain("hello jeff");
+    });
+});


### PR DESCRIPTION
To integrate with Autify Connect Client, we add two commands for POC:

- `autify connect access-point set`
- `autify connect client start`

With these commands, the customer can store an Access Point information
and start Autify Connect Client without downloading its binary manually.

We also expand `autify web test run` by adding `--autify-connect-client`
flag. This single option starts Autify Connect Client and runs
a test scenario with the associated Access Point. This makes on-demand
test execution with given Access Point much easier.

----

Once we agree the CLI design, we'll add integration tests.