### PR TITLE
Expose `autify-mobile-generate-fake-app`

### DIFF
--- a/integration-test/bin/autify-mobile-generate-fake-app.js
+++ b/integration-test/bin/autify-mobile-generate-fake-app.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require("../dist/bin/autify-mobile-generate-fake-app.js");

--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -5,6 +5,7 @@
   "author": "Autify",
   "bin": {
     "autify-cli-integration-test": "bin/autify-cli-integration-test.js",
+    "autify-mobile-generate-fake-app": "bin/autify-mobile-generate-fake-app.js",
     "autify-with-proxy": "bin/autify-with-proxy.js"
   },
   "homepage": "https://github.com/autifyhq/autify-cli",
@@ -45,8 +46,7 @@
   "scripts": {
     "build": "shx rm -rf dist && tsc -b",
     "prepack": "npm run build",
-    "generate-fake-app": "node dist/test/helpers/generateFakeApp.js",
-    "test": "npm run generate-fake-app && cross-env AUTIFY_TEST_WAIT_INTERVAL_SECOND=0 jest dist/test",
+    "test": "autify-mobile-generate-fake-app && cross-env AUTIFY_TEST_WAIT_INTERVAL_SECOND=0 jest dist/test",
     "test:record": "AUTIFY_POLLY_RECORD=1 jest dist/test --updateSnapshot"
   },
   "engines": {

--- a/integration-test/src/bin/autify-mobile-generate-fake-app.ts
+++ b/integration-test/src/bin/autify-mobile-generate-fake-app.ts
@@ -1,7 +1,6 @@
-/* eslint-disable unicorn/filename-case */
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { androidBuildPath, iosBuildPath } from "../../commands";
+import { androidBuildPath, iosBuildPath } from "../commands";
 
 // https://commons.wikimedia.org/wiki/File:Transparent.gif
 const tinyBinary = Buffer.from(
@@ -16,10 +15,12 @@ if (existsSync(iosBuildPath)) {
 } else {
   mkdirSync(iosBuildPath); // *.app is a directory
   writeFileSync(join(iosBuildPath, "ios"), tinyBinary); // Add a fake binary file
+  console.log(`${iosBuildPath} is created.`);
 }
 
 if (existsSync(androidBuildPath)) {
   console.log(`${androidBuildPath} already exists.`);
 } else {
   writeFileSync(androidBuildPath, tinyBinary); // Create a fake binary file
+  console.log(`${androidBuildPath} is created.`);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
       },
       "bin": {
         "autify-cli-integration-test": "bin/autify-cli-integration-test.js",
+        "autify-mobile-generate-fake-app": "bin/autify-mobile-generate-fake-app.js",
         "autify-with-proxy": "bin/autify-with-proxy.js"
       },
       "devDependencies": {


### PR DESCRIPTION
For mobile CI/CD integration tests, we need to generate fake apps
outside `autify-cli-integration-test`. Hence, exposing the command.

Note: Patch release of https://github.com/autifyhq/autify-cli/pull/86