### PR TITLE
Add mobileBuildUploadIos integration test

### DIFF
--- a/integration-test/__recordings__/mobile%20build%20upload%20--workspace-id%3DnYmF1n%20ios.app/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/mobile%20build%20upload%20--workspace-id%3DnYmF1n%20ios.app/polly-proxy_3343057686/recording.har
@@ -1,0 +1,59 @@
+{
+  "log": {
+    "_recordingName": "polly-proxy",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "7df49c91ebfbf219d57667e05fd60fe8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 396,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "multipart/form-data; boundary=--------------------------495603915481196874159158",
+            "params": []
+          },
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/nYmF1n/builds"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 15,
+            "text": "{\"id\":\"gquRM0\"}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 612,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-08-30T16:29:49.338Z",
+        "time": 15006,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 15006
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/integration-test/__snapshots__/golden/mobileBuildUploadIos.test.js.snap
+++ b/integration-test/__snapshots__/golden/mobileBuildUploadIos.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`autify mobile build upload /path/to/ios.app --workspace-id AAA 1`] = `
+Object {
+  "stderr": "",
+  "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
+[HPM] Proxy created: /  -> https://mobile-app.autify.com
+✅ Successfully uploaded ios.app (ID: gquRM0). See https://mobile-app.autify.com/projects/nYmF1n/builds?os=ios&selectedBuildId=gquRM0&page=1
+[HPM] server close signal received: closing proxy server
+",
+}
+`;

--- a/integration-test/src/bin/autify-cli-integration-test.ts
+++ b/integration-test/src/bin/autify-cli-integration-test.ts
@@ -1,5 +1,4 @@
 import { execSync } from "node:child_process";
-import { platform } from "node:os";
 import path from "node:path";
 import { argv } from "node:process";
 
@@ -7,10 +6,7 @@ import { argv } from "node:process";
 const scriptDir = __dirname;
 const rootDir = path.join(scriptDir, "..", "..");
 const isRecord = argv[2] === "--record";
-let command = isRecord ? "test:record" : "test";
-if (platform() === "win32") {
-  command = `${command} -- --testPathIgnorePatterns mobileTestRunIos`;
-}
+const command = isRecord ? "test:record" : "test";
 
 execSync(`npm run ${command}`, {
   stdio: "inherit",

--- a/integration-test/src/test/golden/mobileBuildUploadIos.test.ts
+++ b/integration-test/src/test/golden/mobileBuildUploadIos.test.ts
@@ -1,0 +1,6 @@
+/* eslint-disable unicorn/filename-case */
+import { testAutifyCliSnapshot } from "../helpers/testAutifyCliSnapshot";
+
+testAutifyCliSnapshot(
+  "mobile build upload /path/to/ios.app --workspace-id AAA"
+);

--- a/integration-test/src/test/helpers/testAutifyCliSnapshot.ts
+++ b/integration-test/src/test/helpers/testAutifyCliSnapshot.ts
@@ -1,8 +1,26 @@
 /* eslint-disable unicorn/filename-case */
+import { platform } from "node:process";
 import { execAutifyCli } from "../helpers/execAutifyCli";
 
+const isSkip = (command: string) => {
+  // Windows doesn't support autify mobile with iOS app upload so far.
+  if (
+    platform === "win32" &&
+    command.startsWith("mobile") &&
+    command.includes(".app")
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
 export const testAutifyCliSnapshot = (command: string): void => {
-  test(`autify ${command}`, async () => {
-    expect(await execAutifyCli(command)).toMatchSnapshot();
-  }, 300_000);
+  (isSkip(command) ? test.skip : test)(
+    `autify ${command}`,
+    async () => {
+      expect(await execAutifyCli(command)).toMatchSnapshot();
+    },
+    300_000
+  );
 };


### PR DESCRIPTION
Just adding one more recording and snapshot for `mobile build upload`
with iOS app file.

Also, moving the skip logic inside `testAutifyCliSnapshot`.

Patch release of https://github.com/autifyhq/autify-cli/pull/93