### PR TITLE
Add `--max-retry-count` to `web/mobile test run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,16 +266,18 @@ Run a test plan.
 ```
 USAGE
   $ autify mobile test run [TEST-PLAN-URL] [--build-id <value> | --build-path <value>] [-w] [-t <value>] [-v]
+    [--max-retry-count <value>]
 
 ARGUMENTS
   TEST-PLAN-URL  Test plan URL e.g. https://mobile-app.autify.com/projects/<ID>/test_plans/<ID>
 
 FLAGS
-  -t, --timeout=<value>  [default: 300] Timeout seconds when waiting for the finish of the test execution.
-  -v, --verbose          Verbose output
-  -w, --wait             Wait until the test finishes.
-  --build-id=<value>     ID of the already uploaded build.
-  --build-path=<value>   File path to the iOS app (*.app) or Android app (*.apk).
+  -t, --timeout=<value>      [default: 300] Timeout seconds when waiting for the finish of the test execution.
+  -v, --verbose              Verbose output
+  -w, --wait                 Wait until the test finishes.
+  --build-id=<value>         ID of the already uploaded build.
+  --build-path=<value>       File path to the iOS app (*.app) or Android app (*.apk).
+  --max-retry-count=<value>  Maximum retry count. The command can take up to timeout * (max-retry-count + 1).
 
 DESCRIPTION
   Run a test plan.
@@ -603,7 +605,7 @@ Run a scenario or test plan.
 USAGE
   $ autify web test run [SCENARIO-OR-TEST-PLAN-URL] [-n <value>] [-r <value>] [--autify-connect <value> |
     --autify-connect-client] [--os <value>] [--os-version <value>] [--browser <value>] [--device <value>] [--device-type
-    <value>] [-w] [-t <value>] [-v]
+    <value>] [-w] [-t <value>] [-v] [--max-retry-count <value>]
 
 ARGUMENTS
   SCENARIO-OR-TEST-PLAN-URL  Scenario URL or Test plan URL e.g.
@@ -620,6 +622,7 @@ FLAGS
   --browser=<value>                  Browser to run the test
   --device=<value>                   Device to run the test
   --device-type=<value>              Device type to run the test
+  --max-retry-count=<value>          Maximum retry count. The command can take up to timeout * (max-retry-count + 1).
   --os=<value>                       OS to run the test
   --os-version=<value>               OS version to run the test
 

--- a/src/commands/mobile/test/wait.ts
+++ b/src/commands/mobile/test/wait.ts
@@ -71,11 +71,12 @@ export default class MobileTestWait extends Command {
       );
       this.exit();
     } else {
-      this.error(
+      this.log(
         `${emoji.get(
           "x"
         )} Test didn't pass. See ${testResultUrl}: ${JSON.stringify(data)}`
       );
+      this.exit(1);
     }
   }
 }

--- a/src/commands/web/test/wait.ts
+++ b/src/commands/web/test/wait.ts
@@ -67,11 +67,12 @@ export default class WebTestWait extends Command {
       );
       this.exit();
     } else {
-      this.error(
+      this.log(
         `${emoji.get(
           "x"
         )} Test didn't pass. See ${testResultUrl}: ${JSON.stringify(data)}`
       );
+      this.exit(1);
     }
   }
 }


### PR DESCRIPTION
Sometime a test scenario is flaky and a few retires can pass it.

Close #102 

### `web test run` test scenario
```
node ➜ /workspaces/autify-cli (feature/retry) $ ./bin/dev web test run https://app.autify.com/projects/743/scenarios/114338 --wait --max-retry-count 1
✅ Successfully started: https://app.autify.com/projects/743/results/1150087 (Capability is Linux Chrome 104.0)
🕐 Waiting for the test result: https://app.autify.com/projects/743/results/1150087
  ✔ Waiting... (timeout: 300 s)
❌ Test didn't pass. See https://app.autify.com/projects/743/results/1150087: {"id":1150087,"status":"failed","duration":6204,"started_at":"2022-09-05T18:14:37.670Z","finished_at":"2022-09-05T18:14:43.875Z","created_at":"2022-09-05T18:14:36.271Z","updated_at":"2022-09-05T18:14:45.444Z","review_needed":false,"test_plan_capability_results":[{"id":1361843,"capability":{"id":361248,"os":"Linux","os_version":null,"browser":"Chrome","browser_version":"104.0","device":null,"created_at":"2022-09-05T18:14:36.247Z","updated_at":"2022-09-05T18:14:36.247Z"},"test_case_results":[{"id":4003892,"test_case_id":114338,"status":"failed","duration":5116,"started_at":"2022-09-05T18:14:38.759Z","finished_at":"2022-09-05T18:14:43.875Z","created_at":"2022-09-05T18:14:37.404Z","project_url":"https://app.autify.com/projects/743/results/1150087/capabilities/1361843/scenarios/4003892","updated_at":"2022-09-05T18:14:45.180Z","review_needed":0}]}],"test_plan":null}
🔁 Retrying... (attempt: 1/1)
✅ Successfully started: https://app.autify.com/projects/743/results/1150088 (Capability is Linux Chrome 104.0)
🕐 Waiting for the test result: https://app.autify.com/projects/743/results/1150088
  ✔ Waiting... (timeout: 300 s)
❌ Test didn't pass. See https://app.autify.com/projects/743/results/1150088: {"id":1150088,"status":"failed","duration":6182,"started_at":"2022-09-05T18:14:47.695Z","finished_at":"2022-09-05T18:14:53.878Z","created_at":"2022-09-05T18:14:46.616Z","updated_at":"2022-09-05T18:14:55.593Z","review_needed":false,"test_plan_capability_results":[{"id":1361844,"capability":{"id":361249,"os":"Linux","os_version":null,"browser":"Chrome","browser_version":"104.0","device":null,"created_at":"2022-09-05T18:14:46.606Z","updated_at":"2022-09-05T18:14:46.606Z"},"test_case_results":[{"id":4003893,"test_case_id":114338,"status":"failed","duration":5138,"started_at":"2022-09-05T18:14:48.740Z","finished_at":"2022-09-05T18:14:53.878Z","created_at":"2022-09-05T18:14:47.396Z","project_url":"https://app.autify.com/projects/743/results/1150088/capabilities/1361844/scenarios/4003893","updated_at":"2022-09-05T18:14:55.091Z","review_needed":0}]}],"test_plan":null}
node ➜ /workspaces/autify-cli (feature/retry) $ echo $?
1
```

### `web test run` test plan
```
node ➜ /workspaces/autify-cli (feature/retry) $ ./bin/dev web test run https://app.autify.com/projects/743/test_plans/234475 --wait --max-retry-count 1
✅ Successfully started: https://app.autify.com/projects/743/results/1150101 (Capability is configured by test plan)
🕐 Waiting for the test result: https://app.autify.com/projects/743/results/1150101
  ✔ Waiting... (timeout: 300 s)
❌ Test didn't pass. See https://app.autify.com/projects/743/results/1150101: {"id":1150101,"status":"failed","duration":5812,"started_at":"2022-09-05T18:21:51.531Z","finished_at":"2022-09-05T18:21:57.344Z","created_at":"2022-09-05T18:21:49.790Z","updated_at":"2022-09-05T18:21:59.039Z","review_needed":false,"test_plan_capability_results":[{"id":1361857,"capability":{"id":361252,"os":"Linux","os_version":"","browser":"Chrome","browser_version":"104.0","device":"","created_at":"2022-09-05T18:19:52.103Z","updated_at":"2022-09-05T18:19:52.103Z"},"test_case_results":[{"id":4003908,"test_case_id":114338,"status":"failed","duration":4648,"started_at":"2022-09-05T18:21:52.696Z","finished_at":"2022-09-05T18:21:57.344Z","created_at":"2022-09-05T18:21:50.602Z","project_url":"https://app.autify.com/projects/743/results/1150101/capabilities/1361857/scenarios/4003908","updated_at":"2022-09-05T18:21:58.626Z","review_needed":0}]}],"test_plan":{"id":234475,"name":"CLI fail","created_at":"2022-09-05T18:19:46.205Z","updated_at":"2022-09-05T18:19:46.205Z"}}
🔁 Retrying... (attempt: 1/1)
✅ Successfully started: https://app.autify.com/projects/743/results/1150102 (Capability is configured by test plan)
🕐 Waiting for the test result: https://app.autify.com/projects/743/results/1150102
  ✔ Waiting... (timeout: 300 s)
❌ Test didn't pass. See https://app.autify.com/projects/743/results/1150102: {"id":1150102,"status":"failed","duration":5629,"started_at":"2022-09-05T18:22:01.233Z","finished_at":"2022-09-05T18:22:06.863Z","created_at":"2022-09-05T18:21:59.637Z","updated_at":"2022-09-05T18:22:08.329Z","review_needed":false,"test_plan_capability_results":[{"id":1361858,"capability":{"id":361252,"os":"Linux","os_version":"","browser":"Chrome","browser_version":"104.0","device":"","created_at":"2022-09-05T18:19:52.103Z","updated_at":"2022-09-05T18:19:52.103Z"},"test_case_results":[{"id":4003909,"test_case_id":114338,"status":"failed","duration":4559,"started_at":"2022-09-05T18:22:02.304Z","finished_at":"2022-09-05T18:22:06.863Z","created_at":"2022-09-05T18:22:00.630Z","project_url":"https://app.autify.com/projects/743/results/1150102/capabilities/1361858/scenarios/4003909","updated_at":"2022-09-05T18:22:08.009Z","review_needed":0}]}],"test_plan":{"id":234475,"name":"CLI fail","created_at":"2022-09-05T18:19:46.205Z","updated_at":"2022-09-05T18:19:46.205Z"}}
node ➜ /workspaces/autify-cli (feature/retry) $ echo $?
1
```

### `mobile test run`
```
node ➜ /workspaces/autify-cli (feature/retry) $ ./bin/dev mobile test run https://mobile-app.autify.com/projects/nYmF1n/test_plans/d3t33M --wait --build-id 8DuzpG --max-retry-count 1
✅ Successfully started: https://mobile-app.autify.com/projects/nYmF1n/results/e2tn1G
🕐 Waiting for the test result: https://mobile-app.autify.com/projects/nYmF1n/results/e2tn1G
  ✔ Waiting... (timeout: 300 s)
❌ Test didn't pass. See https://mobile-app.autify.com/projects/nYmF1n/results/e2tn1G: {"id":"e2tn1G","status":"failed","duration":47303,"started_at":"2022-09-06T03:10:44.697+09:00","finished_at":"2022-09-06T03:11:32.000+09:00","created_at":"2022-09-06T03:10:44.483+09:00","updated_at":"2022-09-06T03:10:44.646+09:00","test_plan":{"id":"d3t33M","name":"Autify CLI test FAIL (Android)","created_at":"2022-09-06T03:00:24.262+09:00","updated_at":"2022-09-06T03:01:15.689+09:00"},"test_case_results":[{"id":"zqIPlY","status":"failed","duration":48242,"test_case":{"id":"yNIMlk","environment_variables":[],"build":{"id":"8DuzpG"},"capability":{"os":"android","os_version":"12.0","device":"Pixel 5"}}}]}
🔁 Retrying... (attempt: 1/1)
✅ Successfully started: https://mobile-app.autify.com/projects/nYmF1n/results/RGt3ko
🕐 Waiting for the test result: https://mobile-app.autify.com/projects/nYmF1n/results/RGt3ko
  ✔ Waiting... (timeout: 300 s)
❌ Test didn't pass. See https://mobile-app.autify.com/projects/nYmF1n/results/RGt3ko: {"id":"RGt3ko","status":"failed","duration":45677,"started_at":"2022-09-06T03:11:39.322+09:00","finished_at":"2022-09-06T03:12:25.000+09:00","created_at":"2022-09-06T03:11:38.959+09:00","updated_at":"2022-09-06T03:11:39.296+09:00","test_plan":{"id":"d3t33M","name":"Autify CLI test FAIL (Android)","created_at":"2022-09-06T03:00:24.262+09:00","updated_at":"2022-09-06T03:01:15.689+09:00"},"test_case_results":[{"id":"6GIV4g","status":"failed","duration":46566,"test_case":{"id":"yNIMlk","environment_variables":[],"build":{"id":"8DuzpG"},"capability":{"os":"android","os_version":"12.0","device":"Pixel 5"}}}]}
node ➜ /workspaces/autify-cli (feature/retry) $ echo $?
1
```
