### PR TITLE
Add `--web-workspace-id` to `connect client start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,13 @@ EXAMPLES
 
 ```
 USAGE
-  $ autify connect client start [--verbose] [--file-logging]
+  $ autify connect client start [--verbose] [--file-logging] [--web-workspace-id <value>]
 
 FLAGS
-  --file-logging  Logging Autify Connect Client log to a file instead of console.
-  --verbose       Make the operation more talkative.
+  --file-logging              Logging Autify Connect Client log to a file instead of console.
+  --verbose                   Make the operation more talkative.
+  --web-workspace-id=<value>  Workspace ID of Autify for Web to create an ephemeral Access Point. If not specified, it
+                              will use the one configured by `autify connect access-point set`, instead.
 
 DESCRIPTION
   [Experimental] Start Autify Connect Client

--- a/src/commands/connect/client/start.ts
+++ b/src/commands/connect/client/start.ts
@@ -1,5 +1,22 @@
+import { WebClient } from "@autifyhq/autify-sdk";
 import { Command, Flags } from "@oclif/core";
 import { spawnClient } from "../../../autify/connect/spawnClient";
+import { get, getOrThrow } from "../../../config";
+
+const createEphemeralAccessPointIfNeeded = (
+  configDir: string,
+  userAgent: string,
+  workspaceId?: number
+) => {
+  if (!workspaceId) return;
+  const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
+  const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
+  const webClient = new WebClient(accessToken, { basePath, userAgent });
+  return {
+    webClient,
+    workspaceId,
+  };
+};
 
 export default class ConnectClientStart extends Command {
   static description = "[Experimental] Start Autify Connect Client";
@@ -16,17 +33,31 @@ export default class ConnectClientStart extends Command {
         "Logging Autify Connect Client log to a file instead of console.",
       default: false,
     }),
+    "web-workspace-id": Flags.integer({
+      description:
+        "Workspace ID of Autify for Web to create an ephemeral Access Point. If not specified, it will use the one configured by `autify connect access-point set`, instead.",
+    }),
   };
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(ConnectClientStart);
-    const { configDir, cacheDir } = this.config;
-    const verbose = flags.verbose;
-    const fileLogging = flags["file-logging"];
+    const { configDir, cacheDir, userAgent } = this.config;
+    const {
+      verbose,
+      "file-logging": fileLogging,
+      "web-workspace-id": webWorkspaceId,
+    } = flags;
+    const ephemeralAccessPoint = createEphemeralAccessPointIfNeeded(
+      configDir,
+      userAgent,
+      webWorkspaceId
+    );
+
     const { version, logFile, accessPointName, waitReady, waitExit } =
       await spawnClient(configDir, cacheDir, {
         verbose,
         fileLogging,
+        ephemeralAccessPoint,
       });
     this.log(
       `Starting Autify Connect Client for Access Point "${accessPointName}" (${version})...`
@@ -35,7 +66,11 @@ export default class ConnectClientStart extends Command {
     this.log("Waiting until Autify Connect Client is ready...");
     await waitReady();
     this.log("Autify Connect Client is ready!");
-    const [code, signal] = await waitExit();
+    const [code, signal, deletedAccessPointName] = await waitExit();
+    if (deletedAccessPointName)
+      this.log(
+        `Autify Connect Access Point was deleted: "${deletedAccessPointName}"`
+      );
     this.log(
       `Autify Connect Client exited (code: ${code}, signal: ${signal}).`
     );

--- a/src/commands/web/test/run.ts
+++ b/src/commands/web/test/run.ts
@@ -230,11 +230,11 @@ export default class WebTestRun extends Command {
       if (autifyConnectClient) {
         this.log("Waiting until Autify Connect Client exits...");
         autifyConnectClient.kill();
-        const [code, signal, deleteAccessPointName] =
+        const [code, signal, deletedAccessPointName] =
           await autifyConnectClient.waitExit();
-        if (deleteAccessPointName)
+        if (deletedAccessPointName)
           this.log(
-            `Autify Connect Access Point was deleted: "${deleteAccessPointName}"`
+            `Autify Connect Access Point was deleted: "${deletedAccessPointName}"`
           );
         this.log(
           `Autify Connect Client exited (code: ${code}, signal: ${signal}).`


### PR DESCRIPTION
By this change, `connect client start` can create/delete an ephemeral access point on the specified workspace.