### PR TITLE
Add `linux-arm64` binary

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -16,6 +16,7 @@ jobs:
             "darwin-arm64",
             "darwin-x64",
             "linux-arm",
+            "linux-arm64",
             "linux-x64",
             "win32-x86",
             "win32-x64",

--- a/install-cicd.bash
+++ b/install-cicd.bash
@@ -15,8 +15,10 @@ fi
 ARCH="$(uname -m)"
 if [ "$ARCH" == "x86_64" ]; then
   ARCH=x64
-elif [[ "$ARCH" == aarch* ]]; then
+elif [ "$ARCH" == "armv7l" ]; then
   ARCH=arm
+elif [ "$ARCH" == "aarch64" ]; then
+  ARCH=arm64
 elif [ "$ARCH" == "arm64" ]; then
   ARCH=arm64
 else

--- a/install-standalone.sh
+++ b/install-standalone.sh
@@ -33,8 +33,10 @@
   ARCH="\$(uname -m)"
   if [ "\$ARCH" == "x86_64" ]; then
     ARCH=x64
-  elif [[ "\$ARCH" == aarch* ]]; then
+  elif [ "\$ARCH" == "armv7l" ]; then
     ARCH=arm
+  elif [ "\$ARCH" == "aarch64" ]; then
+    ARCH=arm64
   elif [ "\$ARCH" == "arm64" ]; then
     ARCH=arm64
   else

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -160,8 +160,10 @@ const promoteShellInstaller = (file: string, channel: string) => {
 
 const promoteS3 = () => {
   const indexes = channel === "stable" ? "--indexes" : "";
+  const targets =
+    "darwin-arm64,darwin-x64,linux-arm,linux-arm64,linux-x64,win32-x86,win32-x64";
   oclif(
-    `promote --channel ${channel} --version ${version} --sha ${sha} ${indexes} --win --macos --xz`
+    `promote --channel ${channel} --version ${version} --sha ${sha} ${indexes} --targets ${targets} --win --macos --xz`
   );
   promoteShellInstaller("install-standalone.sh", channel);
   promoteShellInstaller("install-cicd.bash", channel);


### PR DESCRIPTION
We provides only 32 bit binary for Arm and it doesn't work well on 64 bit Linux.

This commit provides the `linux-arm64` binary as well as updates on the installer script.

Close #108 