### PR TITLE
Add supported `autifyconnect` version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See our official document: https://help.autify.com/docs/autify-command-line-inte
 <!-- commands -->
 
 - [`autify connect access-point set`](#autify-connect-access-point-set)
-- [`autify connect client install`](#autify-connect-client-install)
+- [`autify connect client install [VERSION]`](#autify-connect-client-install-version)
 - [`autify connect client start`](#autify-connect-client-start)
 - [`autify help [COMMAND]`](#autify-help-command)
 - [`autify mobile api describe-test-result`](#autify-mobile-api-describe-test-result)
@@ -73,19 +73,32 @@ EXAMPLES
     $ autify connect access-point set --name=NAME < key.txt
 ```
 
-## `autify connect client install`
+## `autify connect client install [VERSION]`
 
-[Experimental] Install the latest stable version of Autify Connect Client
+[Experimental] Install Autify Connect Client
 
 ```
 USAGE
-  $ autify connect client install
+  $ autify connect client install [VERSION]
+
+ARGUMENTS
+  VERSION  [default: v0.6.1] Specify the target version of Autify Connect Client.
 
 DESCRIPTION
-  [Experimental] Install the latest stable version of Autify Connect Client
+  [Experimental] Install Autify Connect Client
 
 EXAMPLES
-  $ autify connect client install
+  (Recommended) Install the supported version:
+
+    $ autify connect client install
+
+  Install a specific version:
+
+    $ autify connect client install v0.6.1
+
+  Install a stable version:
+
+    $ autify connect client install stable
 ```
 
 ## `autify connect client start`

--- a/src/commands/connect/client/install.ts
+++ b/src/commands/connect/client/install.ts
@@ -1,20 +1,42 @@
-import { Command } from "@oclif/core";
-import { installClient } from "../../../autify/connect/installClient";
+import { CliUx, Command } from "@oclif/core";
+import {
+  AUTIFY_CONNECT_CLIENT_SUPPORTED_VERSION,
+  installClient,
+} from "../../../autify/connect/installClient";
 
 export default class ConnectClientInstall extends Command {
-  static description =
-    "[Experimental] Install the latest stable version of Autify Connect Client";
+  static description = "[Experimental] Install Autify Connect Client";
 
-  static examples = ["<%= config.bin %> <%= command.id %>"];
+  static examples = [
+    "(Recommended) Install the supported version:\n<%= config.bin %> <%= command.id %>",
+    "Install a specific version:\n<%= config.bin %> <%= command.id %> v0.6.1",
+    "Install a stable version:\n<%= config.bin %> <%= command.id %> stable",
+  ];
 
   static flags = {};
 
-  static args = [];
+  static args = [
+    {
+      name: "version",
+      description: "Specify the target version of Autify Connect Client.",
+      default: AUTIFY_CONNECT_CLIENT_SUPPORTED_VERSION,
+    },
+  ];
 
   public async run(): Promise<void> {
-    await this.parse(ConnectClientInstall);
+    const { args } = await this.parse(ConnectClientInstall);
     const { configDir, cacheDir } = this.config;
-    const { version, path } = await installClient(configDir, cacheDir);
+    CliUx.ux.action.start(
+      `Installing Autify Connect Client (version: ${args.version})`,
+      "installing",
+      { stdout: true }
+    );
+    const { version, path } = await installClient(
+      configDir,
+      cacheDir,
+      args.version as string
+    );
+    CliUx.ux.action.stop();
     this.log(
       `Successfully installed Autify Connect Client (path: ${path}, version: ${version})`
     );

--- a/src/commands/connect/client/start.ts
+++ b/src/commands/connect/client/start.ts
@@ -53,15 +53,23 @@ export default class ConnectClientStart extends Command {
       webWorkspaceId
     );
 
-    const { version, logFile, accessPointName, waitReady, waitExit } =
-      await spawnClient(configDir, cacheDir, {
-        verbose,
-        fileLogging,
-        ephemeralAccessPoint,
-      });
+    const {
+      version,
+      versionMismatchWarning,
+      logFile,
+      accessPointName,
+      waitReady,
+      waitExit,
+    } = await spawnClient(configDir, cacheDir, {
+      verbose,
+      fileLogging,
+      ephemeralAccessPoint,
+    });
     this.log(
       `Starting Autify Connect Client for Access Point "${accessPointName}" (${version})...`
     );
+    if (versionMismatchWarning) this.warn(versionMismatchWarning);
+
     if (logFile) this.log(`Log file is located at ${logFile}`);
     this.log("Waiting until Autify Connect Client is ready...");
     await waitReady();

--- a/src/commands/web/test/run.ts
+++ b/src/commands/web/test/run.ts
@@ -154,12 +154,18 @@ export default class WebTestRun extends Command {
           workspaceId,
         },
       });
-      const { version, logFile, accessPointName, waitReady } =
-        autifyConnectClient;
+      const {
+        version,
+        versionMismatchWarning,
+        logFile,
+        accessPointName,
+        waitReady,
+      } = autifyConnectClient;
       autifyConnectAccessPoint = accessPointName;
       this.log(
         `Starting Autify Connect Client for Access Point "${accessPointName}" (${version})...`
       );
+      if (versionMismatchWarning) this.warn(versionMismatchWarning);
       if (logFile)
         this.log(`Autify Connect Client log file is located at ${logFile}`);
       this.log("Waiting until Autify Connect Client is ready...");


### PR DESCRIPTION
We should lock the version of `autifyconnect` to avoid using backward incompatible release of `autifyconnect` and keep our integration tests idempotent.

This commit introduces "supported version" hard coded and installing that version by `connect client install` by default.

Optionally, the customers can install any specific version for some reasons, but we'll warn them when running `connect client start` or `web test run --autify-connect-client`.