### PR TITLE
Support debug server of Autify Connect client

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,15 @@ EXAMPLES
 
 ```
 USAGE
-  $ autify connect client start [--verbose] [--file-logging] [--web-workspace-id <value>]
+  $ autify connect client start [--verbose] [--file-logging] [--debug-server-port <value>] [--web-workspace-id <value>]
 
 FLAGS
-  --file-logging              Logging Autify Connect Client log to a file instead of console.
-  --verbose                   Make the operation more talkative.
-  --web-workspace-id=<value>  Workspace ID of Autify for Web to create an ephemeral Access Point. If not specified, it
-                              will use the one configured by `autify connect access-point set`, instead.
+  --debug-server-port=<value>  [default: 3000] The server for debugging and monitoring launches on your local machine on
+                               the given port.
+  --file-logging               Logging Autify Connect Client log to a file instead of console.
+  --verbose                    Make the operation more talkative.
+  --web-workspace-id=<value>   Workspace ID of Autify for Web to create an ephemeral Access Point. If not specified, it
+                               will use the one configured by `autify connect access-point set`, instead.
 
 DESCRIPTION
   [Experimental] Start Autify Connect Client
@@ -619,32 +621,38 @@ Run a scenario or test plan.
 ```
 USAGE
   $ autify web test run [SCENARIO-OR-TEST-PLAN-URL] [-n <value>] [-r <value>] [--autify-connect <value> |
-    --autify-connect-client] [--autify-connect-client-verbose ] [--autify-connect-client-file-logging ] [--os <value>]
-    [--os-version <value>] [--browser <value>] [--device <value>] [--device-type <value>] [-w] [-t <value>] [-v]
-    [--max-retry-count <value>]
+    --autify-connect-client] [--autify-connect-client-verbose ] [--autify-connect-client-file-logging ]
+    [--autify-connect-client-debug-server-port <value> ] [--os <value>] [--os-version <value>] [--browser <value>]
+    [--device <value>] [--device-type <value>] [-w] [-t <value>] [-v] [--max-retry-count <value>]
 
 ARGUMENTS
   SCENARIO-OR-TEST-PLAN-URL  Scenario URL or Test plan URL e.g.
                              https://app.autify.com/projects/<ID>/(scenarios|test_plans)/<ID>
 
 FLAGS
-  -n, --name=<value>                    Name of the test execution. (Only for test scenario execution.)
-  -r, --url-replacements=<value>...     URL replacements. Example: http://example.com=http://example.net
-  -t, --timeout=<value>                 [default: 300] Timeout seconds when waiting for the finish of the test
-                                        execution.
-  -v, --verbose                         Verbose output
-  -w, --wait                            Wait until the test finishes.
-  --autify-connect=<value>              Name of the Autify Connect Access Point (Only for test scenario execution.)
-  --autify-connect-client               [Experimental] Start Autify Connect Client (Only for test scenario execution.)
-  --autify-connect-client-file-logging  [Experimental] Logging Autify Connect Client log to a file instead of console.
-  --autify-connect-client-verbose       [Experimental] Verbose output for Autify Connect Client (Only for test scenario
-                                        execution.)
-  --browser=<value>                     Browser to run the test
-  --device=<value>                      Device to run the test
-  --device-type=<value>                 Device type to run the test
-  --max-retry-count=<value>             Maximum retry count. The command can take up to timeout * (max-retry-count + 1).
-  --os=<value>                          OS to run the test
-  --os-version=<value>                  OS version to run the test
+  -n, --name=<value>                                 Name of the test execution. (Only for test scenario execution.)
+  -r, --url-replacements=<value>...                  URL replacements. Example: http://example.com=http://example.net
+  -t, --timeout=<value>                              [default: 300] Timeout seconds when waiting for the finish of the
+                                                     test execution.
+  -v, --verbose                                      Verbose output
+  -w, --wait                                         Wait until the test finishes.
+  --autify-connect=<value>                           Name of the Autify Connect Access Point (Only for test scenario
+                                                     execution.)
+  --autify-connect-client                            [Experimental] Start Autify Connect Client (Only for test scenario
+                                                     execution.)
+  --autify-connect-client-debug-server-port=<value>  [Experimental] [default: 3000] Port for Autify Connect Client debug
+                                                     server.
+  --autify-connect-client-file-logging               [Experimental] Logging Autify Connect Client log to a file instead
+                                                     of console.
+  --autify-connect-client-verbose                    [Experimental] Verbose output for Autify Connect Client (Only for
+                                                     test scenario execution.)
+  --browser=<value>                                  Browser to run the test
+  --device=<value>                                   Device to run the test
+  --device-type=<value>                              Device type to run the test
+  --max-retry-count=<value>                          Maximum retry count. The command can take up to timeout *
+                                                     (max-retry-count + 1).
+  --os=<value>                                       OS to run the test
+  --os-version=<value>                               OS version to run the test
 
 DESCRIPTION
   Run a scenario or test plan.

--- a/integration-test/__recordings__/web%20test%20run%20--autify-connect-client%20--wait%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Fscenarios%2F91437/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/web%20test%20run%20--autify-connect-client%20--wait%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Fscenarios%2F91437/polly-proxy_3343057686/recording.har
@@ -21,7 +21,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"name\":\"autify-cli-ed5323e0-1163-4f5f-99fe-0a6f3388027a\"}"
+            "text": "{\"name\":\"autify-cli-7a864685-ec4b-48cd-b9cf-2d39c35ae863\"}"
           },
           "queryString": [],
           "url": "https://app.autify.com/api/v1/projects/743/autify_connect/access_points"
@@ -31,7 +31,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 211,
-            "text": "{\"name\":\"autify-cli-ed5323e0-1163-4f5f-99fe-0a6f3388027a\",\"key\":\"000000000000000000000000000000\",\"last_use\":null,\"creator\":\"riywo\",\"created_at\":\"2022-09-09T02:20:06.332Z\",\"updated_at\":\"2022-09-09T02:20:06.332Z\"}"
+            "text": "{\"name\":\"autify-cli-7a864685-ec4b-48cd-b9cf-2d39c35ae863\",\"key\":\"000000000000000000000000000000\",\"last_use\":null,\"creator\":\"riywo\",\"created_at\":\"2022-09-12T20:40:39.109Z\",\"updated_at\":\"2022-09-12T20:40:39.109Z\"}"
           },
           "cookies": [],
           "headers": [],
@@ -41,8 +41,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-09T02:20:05.648Z",
-        "time": 752,
+        "startedDateTime": "2022-09-12T20:40:38.366Z",
+        "time": 795,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -50,7 +50,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 752
+          "wait": 795
         }
       },
       {
@@ -76,7 +76,7 @@
           },
           "cookies": [
             {
-              "expires": "2042-09-09T02:20:08.000Z",
+              "expires": "2042-09-12T20:40:39.000Z",
               "httpOnly": true,
               "name": "current_project_id",
               "path": "/",
@@ -91,8 +91,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-09T02:20:07.633Z",
-        "time": 513,
+        "startedDateTime": "2022-09-12T20:40:39.187Z",
+        "time": 543,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -100,11 +100,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 513
+          "wait": 543
         }
       },
       {
-        "_id": "cb1e8ae5e37ec78316da79149269203d",
+        "_id": "41e419a2168c357a5c0c11a1fef62e99",
         "_order": 0,
         "cache": {},
         "request": {
@@ -117,7 +117,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"capabilities\":[{\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"device_type\":null,\"unsupported\":false}],\"scenarios\":[{\"id\":91437}],\"url_replacements\":[],\"autify_connect\":{\"name\":\"autify-cli-ed5323e0-1163-4f5f-99fe-0a6f3388027a\"}}"
+            "text": "{\"capabilities\":[{\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"device_type\":null,\"unsupported\":false}],\"scenarios\":[{\"id\":91437}],\"url_replacements\":[],\"autify_connect\":{\"name\":\"autify-cli-7a864685-ec4b-48cd-b9cf-2d39c35ae863\"}}"
           },
           "queryString": [],
           "url": "https://app.autify.com/api/v1/projects/743/execute_scenarios"
@@ -127,7 +127,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 21,
-            "text": "{\"result_id\":1161901}"
+            "text": "{\"result_id\":1172264}"
           },
           "cookies": [],
           "headers": [],
@@ -137,8 +137,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-09T02:20:08.154Z",
-        "time": 725,
+        "startedDateTime": "2022-09-12T20:40:39.737Z",
+        "time": 612,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -146,11 +146,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 725
+          "wait": 612
         }
       },
       {
-        "_id": "cd9ba320556209770edfd3aa1852c27f",
+        "_id": "42ae9c61d08b7d7a5e08276b4263be84",
         "_order": 0,
         "cache": {},
         "request": {
@@ -161,14 +161,14 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1161901"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1172264"
         },
         "response": {
-          "bodySize": 239,
+          "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 239,
-            "text": "{\"id\":1161901,\"status\":\"queuing\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2022-09-09T02:20:08.759Z\",\"updated_at\":\"2022-09-09T02:20:08.802Z\",\"review_needed\":false,\"test_plan_capability_results\":[],\"test_plan\":null}"
+            "size": 829,
+            "text": "{\"id\":1172264,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-12T20:40:41.606Z\",\"finished_at\":null,\"created_at\":\"2022-09-12T20:40:40.274Z\",\"updated_at\":\"2022-09-12T20:40:41.638Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1387812,\"capability\":{\"id\":366124,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-12T20:40:40.259Z\",\"updated_at\":\"2022-09-12T20:40:40.259Z\"},\"test_case_results\":[{\"id\":4093532,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-12T20:40:41.606Z\",\"finished_at\":null,\"created_at\":\"2022-09-12T20:40:41.045Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1172264/capabilities/1387812/scenarios/4093532\",\"updated_at\":\"2022-09-12T20:40:41.716Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -178,8 +178,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-09T02:20:09.905Z",
-        "time": 458,
+        "startedDateTime": "2022-09-12T20:40:41.375Z",
+        "time": 513,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -187,11 +187,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 458
+          "wait": 513
         }
       },
       {
-        "_id": "cd9ba320556209770edfd3aa1852c27f",
+        "_id": "42ae9c61d08b7d7a5e08276b4263be84",
         "_order": 1,
         "cache": {},
         "request": {
@@ -202,14 +202,14 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1161901"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1172264"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1161901,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-09T02:20:11.183Z\",\"finished_at\":null,\"created_at\":\"2022-09-09T02:20:08.759Z\",\"updated_at\":\"2022-09-09T02:20:11.255Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1375719,\"capability\":{\"id\":364215,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-09T02:20:08.725Z\",\"updated_at\":\"2022-09-09T02:20:08.725Z\"},\"test_case_results\":[{\"id\":4054936,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-09T02:20:11.183Z\",\"finished_at\":null,\"created_at\":\"2022-09-09T02:20:10.861Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1161901/capabilities/1375719/scenarios/4054936\",\"updated_at\":\"2022-09-09T02:20:11.383Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1172264,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-12T20:40:41.606Z\",\"finished_at\":null,\"created_at\":\"2022-09-12T20:40:40.274Z\",\"updated_at\":\"2022-09-12T20:40:41.638Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1387812,\"capability\":{\"id\":366124,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-12T20:40:40.259Z\",\"updated_at\":\"2022-09-12T20:40:40.259Z\"},\"test_case_results\":[{\"id\":4093532,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-12T20:40:41.606Z\",\"finished_at\":null,\"created_at\":\"2022-09-12T20:40:41.045Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1172264/capabilities/1387812/scenarios/4093532\",\"updated_at\":\"2022-09-12T20:40:41.716Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -219,8 +219,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-09T02:20:10.906Z",
-        "time": 578,
+        "startedDateTime": "2022-09-12T20:40:42.374Z",
+        "time": 496,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -228,11 +228,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 578
+          "wait": 496
         }
       },
       {
-        "_id": "cd9ba320556209770edfd3aa1852c27f",
+        "_id": "42ae9c61d08b7d7a5e08276b4263be84",
         "_order": 2,
         "cache": {},
         "request": {
@@ -243,14 +243,14 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1161901"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1172264"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1161901,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-09T02:20:11.183Z\",\"finished_at\":null,\"created_at\":\"2022-09-09T02:20:08.759Z\",\"updated_at\":\"2022-09-09T02:20:11.255Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1375719,\"capability\":{\"id\":364215,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-09T02:20:08.725Z\",\"updated_at\":\"2022-09-09T02:20:08.725Z\"},\"test_case_results\":[{\"id\":4054936,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-09T02:20:11.183Z\",\"finished_at\":null,\"created_at\":\"2022-09-09T02:20:10.861Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1161901/capabilities/1375719/scenarios/4054936\",\"updated_at\":\"2022-09-09T02:20:11.383Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1172264,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-12T20:40:41.606Z\",\"finished_at\":null,\"created_at\":\"2022-09-12T20:40:40.274Z\",\"updated_at\":\"2022-09-12T20:40:41.638Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1387812,\"capability\":{\"id\":366124,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-12T20:40:40.259Z\",\"updated_at\":\"2022-09-12T20:40:40.259Z\"},\"test_case_results\":[{\"id\":4093532,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-12T20:40:41.606Z\",\"finished_at\":null,\"created_at\":\"2022-09-12T20:40:41.045Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1172264/capabilities/1387812/scenarios/4093532\",\"updated_at\":\"2022-09-12T20:40:41.716Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -260,8 +260,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-09T02:20:11.906Z",
-        "time": 457,
+        "startedDateTime": "2022-09-12T20:40:43.375Z",
+        "time": 509,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -269,11 +269,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 457
+          "wait": 509
         }
       },
       {
-        "_id": "cd9ba320556209770edfd3aa1852c27f",
+        "_id": "42ae9c61d08b7d7a5e08276b4263be84",
         "_order": 3,
         "cache": {},
         "request": {
@@ -284,14 +284,14 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1161901"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1172264"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1161901,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-09T02:20:11.183Z\",\"finished_at\":null,\"created_at\":\"2022-09-09T02:20:08.759Z\",\"updated_at\":\"2022-09-09T02:20:11.255Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1375719,\"capability\":{\"id\":364215,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-09T02:20:08.725Z\",\"updated_at\":\"2022-09-09T02:20:08.725Z\"},\"test_case_results\":[{\"id\":4054936,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-09T02:20:11.183Z\",\"finished_at\":null,\"created_at\":\"2022-09-09T02:20:10.861Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1161901/capabilities/1375719/scenarios/4054936\",\"updated_at\":\"2022-09-09T02:20:11.383Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1172264,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-12T20:40:41.606Z\",\"finished_at\":null,\"created_at\":\"2022-09-12T20:40:40.274Z\",\"updated_at\":\"2022-09-12T20:40:41.638Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1387812,\"capability\":{\"id\":366124,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-12T20:40:40.259Z\",\"updated_at\":\"2022-09-12T20:40:40.259Z\"},\"test_case_results\":[{\"id\":4093532,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-12T20:40:41.606Z\",\"finished_at\":null,\"created_at\":\"2022-09-12T20:40:41.045Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1172264/capabilities/1387812/scenarios/4093532\",\"updated_at\":\"2022-09-12T20:40:41.716Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -301,8 +301,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-09T02:20:12.907Z",
-        "time": 552,
+        "startedDateTime": "2022-09-12T20:40:44.376Z",
+        "time": 498,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -310,11 +310,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 552
+          "wait": 498
         }
       },
       {
-        "_id": "cd9ba320556209770edfd3aa1852c27f",
+        "_id": "42ae9c61d08b7d7a5e08276b4263be84",
         "_order": 4,
         "cache": {},
         "request": {
@@ -325,14 +325,14 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1161901"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1172264"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1161901,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-09T02:20:11.183Z\",\"finished_at\":null,\"created_at\":\"2022-09-09T02:20:08.759Z\",\"updated_at\":\"2022-09-09T02:20:11.255Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1375719,\"capability\":{\"id\":364215,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-09T02:20:08.725Z\",\"updated_at\":\"2022-09-09T02:20:08.725Z\"},\"test_case_results\":[{\"id\":4054936,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-09T02:20:11.183Z\",\"finished_at\":null,\"created_at\":\"2022-09-09T02:20:10.861Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1161901/capabilities/1375719/scenarios/4054936\",\"updated_at\":\"2022-09-09T02:20:11.383Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1172264,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-12T20:40:41.606Z\",\"finished_at\":null,\"created_at\":\"2022-09-12T20:40:40.274Z\",\"updated_at\":\"2022-09-12T20:40:41.638Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1387812,\"capability\":{\"id\":366124,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-12T20:40:40.259Z\",\"updated_at\":\"2022-09-12T20:40:40.259Z\"},\"test_case_results\":[{\"id\":4093532,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-12T20:40:41.606Z\",\"finished_at\":null,\"created_at\":\"2022-09-12T20:40:41.045Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1172264/capabilities/1387812/scenarios/4093532\",\"updated_at\":\"2022-09-12T20:40:41.716Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -342,8 +342,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-09T02:20:13.908Z",
-        "time": 546,
+        "startedDateTime": "2022-09-12T20:40:45.375Z",
+        "time": 488,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -351,11 +351,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 546
+          "wait": 488
         }
       },
       {
-        "_id": "cd9ba320556209770edfd3aa1852c27f",
+        "_id": "42ae9c61d08b7d7a5e08276b4263be84",
         "_order": 5,
         "cache": {},
         "request": {
@@ -366,14 +366,14 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1161901"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1172264"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1161901,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-09T02:20:11.183Z\",\"finished_at\":null,\"created_at\":\"2022-09-09T02:20:08.759Z\",\"updated_at\":\"2022-09-09T02:20:11.255Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1375719,\"capability\":{\"id\":364215,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-09T02:20:08.725Z\",\"updated_at\":\"2022-09-09T02:20:08.725Z\"},\"test_case_results\":[{\"id\":4054936,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-09T02:20:11.183Z\",\"finished_at\":null,\"created_at\":\"2022-09-09T02:20:10.861Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1161901/capabilities/1375719/scenarios/4054936\",\"updated_at\":\"2022-09-09T02:20:11.383Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1172264,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-12T20:40:41.606Z\",\"finished_at\":null,\"created_at\":\"2022-09-12T20:40:40.274Z\",\"updated_at\":\"2022-09-12T20:40:41.638Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1387812,\"capability\":{\"id\":366124,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-12T20:40:40.259Z\",\"updated_at\":\"2022-09-12T20:40:40.259Z\"},\"test_case_results\":[{\"id\":4093532,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-12T20:40:41.606Z\",\"finished_at\":null,\"created_at\":\"2022-09-12T20:40:41.045Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1172264/capabilities/1387812/scenarios/4093532\",\"updated_at\":\"2022-09-12T20:40:41.716Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -383,8 +383,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-09T02:20:14.909Z",
-        "time": 493,
+        "startedDateTime": "2022-09-12T20:40:46.376Z",
+        "time": 573,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -392,11 +392,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 493
+          "wait": 573
         }
       },
       {
-        "_id": "cd9ba320556209770edfd3aa1852c27f",
+        "_id": "42ae9c61d08b7d7a5e08276b4263be84",
         "_order": 6,
         "cache": {},
         "request": {
@@ -407,14 +407,14 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1161901"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1172264"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1161901,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-09T02:20:11.183Z\",\"finished_at\":null,\"created_at\":\"2022-09-09T02:20:08.759Z\",\"updated_at\":\"2022-09-09T02:20:11.255Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1375719,\"capability\":{\"id\":364215,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-09T02:20:08.725Z\",\"updated_at\":\"2022-09-09T02:20:08.725Z\"},\"test_case_results\":[{\"id\":4054936,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-09T02:20:11.183Z\",\"finished_at\":null,\"created_at\":\"2022-09-09T02:20:10.861Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1161901/capabilities/1375719/scenarios/4054936\",\"updated_at\":\"2022-09-09T02:20:11.383Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1172264,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-12T20:40:41.606Z\",\"finished_at\":null,\"created_at\":\"2022-09-12T20:40:40.274Z\",\"updated_at\":\"2022-09-12T20:40:41.638Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1387812,\"capability\":{\"id\":366124,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-12T20:40:40.259Z\",\"updated_at\":\"2022-09-12T20:40:40.259Z\"},\"test_case_results\":[{\"id\":4093532,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-12T20:40:41.606Z\",\"finished_at\":null,\"created_at\":\"2022-09-12T20:40:41.045Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1172264/capabilities/1387812/scenarios/4093532\",\"updated_at\":\"2022-09-12T20:40:41.716Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -424,8 +424,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-09T02:20:15.909Z",
-        "time": 503,
+        "startedDateTime": "2022-09-12T20:40:47.376Z",
+        "time": 454,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -433,11 +433,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 503
+          "wait": 454
         }
       },
       {
-        "_id": "cd9ba320556209770edfd3aa1852c27f",
+        "_id": "42ae9c61d08b7d7a5e08276b4263be84",
         "_order": 7,
         "cache": {},
         "request": {
@@ -448,14 +448,14 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1161901"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1172264"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1161901,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-09T02:20:11.183Z\",\"finished_at\":null,\"created_at\":\"2022-09-09T02:20:08.759Z\",\"updated_at\":\"2022-09-09T02:20:11.255Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1375719,\"capability\":{\"id\":364215,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-09T02:20:08.725Z\",\"updated_at\":\"2022-09-09T02:20:08.725Z\"},\"test_case_results\":[{\"id\":4054936,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-09T02:20:11.183Z\",\"finished_at\":null,\"created_at\":\"2022-09-09T02:20:10.861Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1161901/capabilities/1375719/scenarios/4054936\",\"updated_at\":\"2022-09-09T02:20:11.383Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1172264,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-12T20:40:41.606Z\",\"finished_at\":null,\"created_at\":\"2022-09-12T20:40:40.274Z\",\"updated_at\":\"2022-09-12T20:40:41.638Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1387812,\"capability\":{\"id\":366124,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-12T20:40:40.259Z\",\"updated_at\":\"2022-09-12T20:40:40.259Z\"},\"test_case_results\":[{\"id\":4093532,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-12T20:40:41.606Z\",\"finished_at\":null,\"created_at\":\"2022-09-12T20:40:41.045Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1172264/capabilities/1387812/scenarios/4093532\",\"updated_at\":\"2022-09-12T20:40:41.716Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -465,8 +465,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-09T02:20:16.909Z",
-        "time": 565,
+        "startedDateTime": "2022-09-12T20:40:48.375Z",
+        "time": 535,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -474,11 +474,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 565
+          "wait": 535
         }
       },
       {
-        "_id": "cd9ba320556209770edfd3aa1852c27f",
+        "_id": "42ae9c61d08b7d7a5e08276b4263be84",
         "_order": 8,
         "cache": {},
         "request": {
@@ -489,14 +489,14 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1161901"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1172264"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1161901,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-09T02:20:11.183Z\",\"finished_at\":null,\"created_at\":\"2022-09-09T02:20:08.759Z\",\"updated_at\":\"2022-09-09T02:20:11.255Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1375719,\"capability\":{\"id\":364215,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-09T02:20:08.725Z\",\"updated_at\":\"2022-09-09T02:20:08.725Z\"},\"test_case_results\":[{\"id\":4054936,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-09T02:20:11.183Z\",\"finished_at\":null,\"created_at\":\"2022-09-09T02:20:10.861Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1161901/capabilities/1375719/scenarios/4054936\",\"updated_at\":\"2022-09-09T02:20:11.383Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1172264,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-12T20:40:41.606Z\",\"finished_at\":null,\"created_at\":\"2022-09-12T20:40:40.274Z\",\"updated_at\":\"2022-09-12T20:40:41.638Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1387812,\"capability\":{\"id\":366124,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-12T20:40:40.259Z\",\"updated_at\":\"2022-09-12T20:40:40.259Z\"},\"test_case_results\":[{\"id\":4093532,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-12T20:40:41.606Z\",\"finished_at\":null,\"created_at\":\"2022-09-12T20:40:41.045Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1172264/capabilities/1387812/scenarios/4093532\",\"updated_at\":\"2022-09-12T20:40:41.716Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -506,8 +506,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-09T02:20:17.908Z",
-        "time": 514,
+        "startedDateTime": "2022-09-12T20:40:49.376Z",
+        "time": 462,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -515,11 +515,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 514
+          "wait": 462
         }
       },
       {
-        "_id": "cd9ba320556209770edfd3aa1852c27f",
+        "_id": "42ae9c61d08b7d7a5e08276b4263be84",
         "_order": 9,
         "cache": {},
         "request": {
@@ -530,55 +530,14 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1161901"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1161901,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-09T02:20:11.183Z\",\"finished_at\":null,\"created_at\":\"2022-09-09T02:20:08.759Z\",\"updated_at\":\"2022-09-09T02:20:11.255Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1375719,\"capability\":{\"id\":364215,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-09T02:20:08.725Z\",\"updated_at\":\"2022-09-09T02:20:08.725Z\"},\"test_case_results\":[{\"id\":4054936,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-09T02:20:11.183Z\",\"finished_at\":null,\"created_at\":\"2022-09-09T02:20:10.861Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1161901/capabilities/1375719/scenarios/4054936\",\"updated_at\":\"2022-09-09T02:20:11.383Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2022-09-09T02:20:18.909Z",
-        "time": 463,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 463
-        }
-      },
-      {
-        "_id": "cd9ba320556209770edfd3aa1852c27f",
-        "_order": 10,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 275,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1161901"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1172264"
         },
         "response": {
           "bodySize": 871,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 871,
-            "text": "{\"id\":1161901,\"status\":\"passed\",\"duration\":6618,\"started_at\":\"2022-09-09T02:20:11.183Z\",\"finished_at\":\"2022-09-09T02:20:17.802Z\",\"created_at\":\"2022-09-09T02:20:08.759Z\",\"updated_at\":\"2022-09-09T02:20:20.055Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1375719,\"capability\":{\"id\":364215,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-09T02:20:08.725Z\",\"updated_at\":\"2022-09-09T02:20:08.725Z\"},\"test_case_results\":[{\"id\":4054936,\"test_case_id\":91437,\"status\":\"passed\",\"duration\":5312,\"started_at\":\"2022-09-09T02:20:12.490Z\",\"finished_at\":\"2022-09-09T02:20:17.802Z\",\"created_at\":\"2022-09-09T02:20:10.861Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1161901/capabilities/1375719/scenarios/4054936\",\"updated_at\":\"2022-09-09T02:20:19.963Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1172264,\"status\":\"passed\",\"duration\":6678,\"started_at\":\"2022-09-12T20:40:41.606Z\",\"finished_at\":\"2022-09-12T20:40:48.285Z\",\"created_at\":\"2022-09-12T20:40:40.274Z\",\"updated_at\":\"2022-09-12T20:40:50.305Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1387812,\"capability\":{\"id\":366124,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-12T20:40:40.259Z\",\"updated_at\":\"2022-09-12T20:40:40.259Z\"},\"test_case_results\":[{\"id\":4093532,\"test_case_id\":91437,\"status\":\"passed\",\"duration\":5214,\"started_at\":\"2022-09-12T20:40:43.071Z\",\"finished_at\":\"2022-09-12T20:40:48.285Z\",\"created_at\":\"2022-09-12T20:40:41.045Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1172264/capabilities/1387812/scenarios/4093532\",\"updated_at\":\"2022-09-12T20:40:50.165Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -588,8 +547,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-09T02:20:19.910Z",
-        "time": 527,
+        "startedDateTime": "2022-09-12T20:40:50.375Z",
+        "time": 488,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -597,7 +556,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 527
+          "wait": 488
         }
       },
       {
@@ -614,7 +573,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"name\":\"autify-cli-ed5323e0-1163-4f5f-99fe-0a6f3388027a\"}"
+            "text": "{\"name\":\"autify-cli-7a864685-ec4b-48cd-b9cf-2d39c35ae863\"}"
           },
           "queryString": [],
           "url": "https://app.autify.com/api/v1/projects/743/autify_connect/access_points"
@@ -634,8 +593,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-09T02:20:20.448Z",
-        "time": 553,
+        "startedDateTime": "2022-09-12T20:40:50.874Z",
+        "time": 514,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -643,7 +602,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 553
+          "wait": 514
         }
       }
     ],

--- a/integration-test/__snapshots__/golden/webTestRunAutifyConnectClient.test.js.snap
+++ b/integration-test/__snapshots__/golden/webTestRunAutifyConnectClient.test.js.snap
@@ -5,15 +5,15 @@ Object {
   "stderr": "",
   "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
 [HPM] Proxy created: /  -> https://mobile-app.autify.com
-Starting Autify Connect Client for Access Point \\"autify-cli-ed5323e0-1163-4f5f-99fe-0a6f3388027a\\" (Autify Connect version fake)...
+Starting Autify Connect Client for Access Point \\"autify-cli-7a864685-ec4b-48cd-b9cf-2d39c35ae863\\" (Autify Connect version fake)...
 Waiting until Autify Connect Client is ready...
+[Autify Connect Client] YYYY-MM-DDTHH:MM:SS.MMMZ info 	start serving a debug server on http://localhost:3000
 [Autify Connect Client] YYYY-MM-DDTHH:MM:SS.MMMZ info 	Starting to establish a secure connection with the Autify connect server. Your session ID is \\"fake\\".
 [Autify Connect Client] YYYY-MM-DDTHH:MM:SS.MMMZ info 	Successfully connected!
 Autify Connect Client is ready!
-✅ Successfully started: https://app.autify.com/projects/743/results/1161901 (Capability is Linux Chrome 104.0)
-🕐 Waiting for the test result: https://app.autify.com/projects/743/results/1161901
+✅ Successfully started: https://app.autify.com/projects/743/results/1172264 (Capability is Linux Chrome 104.0)
+🕐 Waiting for the test result: https://app.autify.com/projects/743/results/1172264
 [HH:MM:SS] Waiting... (timeout: 300 s) [started]
-[HH:MM:SS] → TestPlan: 🌀 Queuing, TestCases: 
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
@@ -25,9 +25,9 @@ Autify Connect Client is ready!
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 👍 Passed , TestCases: 👍 Passed 
 [HH:MM:SS] Waiting... (timeout: 300 s) [completed]
-✅ Test passed!: https://app.autify.com/projects/743/results/1161901
+✅ Test passed!: https://app.autify.com/projects/743/results/1172264
 Waiting until Autify Connect Client exits...
-Autify Connect Access Point was deleted: \\"autify-cli-ed5323e0-1163-4f5f-99fe-0a6f3388027a\\"
+Autify Connect Access Point was deleted: \\"autify-cli-7a864685-ec4b-48cd-b9cf-2d39c35ae863\\"
 Autify Connect Client exited
 [HPM] server close signal received: closing proxy server
 ",


### PR DESCRIPTION
Autify Connect Client added a experimental feature to provide a debug server for communicating with the client.

This commit adds support for that debug server and use it for `waitReady()` and `kill()` (not implemented yet by `autifyconnect`).

Also, moved some logics to properly finalize the commands.