### PR TITLE
Add `connect access-point create`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ See our official document: https://help.autify.com/docs/autify-command-line-inte
 
 <!-- commands -->
 
+- [`autify connect access-point create`](#autify-connect-access-point-create)
 - [`autify connect access-point set`](#autify-connect-access-point-set)
 - [`autify connect client install [VERSION]`](#autify-connect-client-install-version)
 - [`autify connect client start`](#autify-connect-client-start)
@@ -48,6 +49,25 @@ See our official document: https://help.autify.com/docs/autify-command-line-inte
 - [`autify web auth login`](#autify-web-auth-login)
 - [`autify web test run SCENARIO-OR-TEST-PLAN-URL`](#autify-web-test-run-scenario-or-test-plan-url)
 - [`autify web test wait TEST-RESULT-URL`](#autify-web-test-wait-test-result-url)
+
+## `autify connect access-point create`
+
+[Experimental] Create an Autify Connect Access Point
+
+```
+USAGE
+  $ autify connect access-point create --name <value> [--web-workspace-id <value>]
+
+FLAGS
+  --name=<value>              (required) Name of Autify Connect Access Point to be created
+  --web-workspace-id=<value>  Workspace ID of Autify for Web to which the Access Point belong
+
+DESCRIPTION
+  [Experimental] Create an Autify Connect Access Point
+
+EXAMPLES
+  $ autify connect access-point create --name NAME --web-workspace-id ID
+```
 
 ## `autify connect access-point set`
 

--- a/src/autify/connect/accessPointConfig.ts
+++ b/src/autify/connect/accessPointConfig.ts
@@ -1,0 +1,39 @@
+/* eslint-disable unicorn/filename-case */
+import { CLIError } from "@oclif/errors";
+import inquirer from "inquirer";
+import { get, set } from "../../config";
+
+export const confirmOverwriteAccessPoint = async (
+  configDir: string
+): Promise<void> => {
+  const existingName = get(configDir, "AUTIFY_CONNECT_ACCESS_POINT_NAME");
+  if (existingName) {
+    const message = `You've already set an Access Point at ${configDir} (name: ${existingName}). Are you ok to clear its configuration from this machine?`;
+    const res = await inquirer.prompt([
+      {
+        name: "confirmed",
+        message,
+        type: "confirm",
+        default: false,
+      },
+    ]);
+    if (!res.confirmed) {
+      throw new CLIError(
+        `Cancelled to overwrite the existing Access Point. It stays as is (name: ${existingName})`
+      );
+    }
+  }
+};
+
+export const saveAccessPoint = (
+  configDir: string,
+  name: string,
+  key: string
+): string => {
+  set(configDir, "AUTIFY_CONNECT_ACCESS_POINT_NAME", name);
+  set(configDir, "AUTIFY_CONNECT_ACCESS_POINT_KEY", key);
+  return (
+    `Access Point name (${name}) and key (****) are stored in ${configDir}. ` +
+    "Execute `autify connect client start` to start a client with this Access Point."
+  );
+};

--- a/src/commands/connect/access-point/create.ts
+++ b/src/commands/connect/access-point/create.ts
@@ -1,0 +1,49 @@
+import { WebClient } from "@autifyhq/autify-sdk";
+import { Command, Flags } from "@oclif/core";
+import {
+  confirmOverwriteAccessPoint,
+  saveAccessPoint,
+} from "../../../autify/connect/accessPointConfig";
+import { get, getOrThrow } from "../../../config";
+
+export default class ConnectAccessPointCreate extends Command {
+  static description = "[Experimental] Create an Autify Connect Access Point";
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %> --name NAME --web-workspace-id ID",
+  ];
+
+  static flags = {
+    name: Flags.string({
+      description: "Name of Autify Connect Access Point to be created",
+      required: true,
+    }),
+    "web-workspace-id": Flags.integer({
+      description:
+        "Workspace ID of Autify for Web to which the Access Point belong",
+      exactlyOne: ["web-workspace-id"],
+    }),
+  };
+
+  static args = [];
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(ConnectAccessPointCreate);
+    const { configDir, userAgent } = this.config;
+    await confirmOverwriteAccessPoint(configDir);
+    const { name, "web-workspace-id": webWorkspaceId } = flags;
+    if (webWorkspaceId) {
+      const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
+      const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
+      const client = new WebClient(accessToken, { basePath, userAgent });
+      const response = await client.createAccessPoint(webWorkspaceId, {
+        name,
+      });
+      const key = response.data.key;
+      this.log(
+        `Successfully created Access Point: (name: ${name}, web-workspace-id: ${webWorkspaceId})`
+      );
+      this.log(saveAccessPoint(configDir, name, key));
+    }
+  }
+}

--- a/src/commands/connect/access-point/set.ts
+++ b/src/commands/connect/access-point/set.ts
@@ -1,6 +1,9 @@
 import { Command, Flags } from "@oclif/core";
 import * as inquirer from "inquirer";
-import { set } from "../../../config";
+import {
+  confirmOverwriteAccessPoint,
+  saveAccessPoint,
+} from "../../../autify/connect/accessPointConfig";
 
 export default class ConnectAccessPointSet extends Command {
   static description = "[Experimental] Set Autify Connect Access Point";
@@ -19,9 +22,11 @@ export default class ConnectAccessPointSet extends Command {
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(ConnectAccessPointSet);
+    const { name } = flags;
+    const { configDir } = this.config;
+    await confirmOverwriteAccessPoint(configDir);
     const key = await this.readKeyFromStdin();
-    set(this.config.configDir, "AUTIFY_CONNECT_ACCESS_POINT_NAME", flags.name);
-    set(this.config.configDir, "AUTIFY_CONNECT_ACCESS_POINT_KEY", key);
+    this.log(saveAccessPoint(configDir, name, key));
   }
 
   private async readKeyFromStdin() {

--- a/test/commands/connect/access-point/create.test.ts
+++ b/test/commands/connect/access-point/create.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "@oclif/test";
+
+describe("connect/access-point/create", () => {
+  test
+    .stdout()
+    .command(["connect/access-point/create"])
+    .it("runs hello", (ctx) => {
+      expect(ctx.stdout).to.contain("hello world");
+    });
+
+  test
+    .stdout()
+    .command(["connect/access-point/create", "--name", "jeff"])
+    .it("runs hello --name jeff", (ctx) => {
+      expect(ctx.stdout).to.contain("hello jeff");
+    });
+});


### PR DESCRIPTION
This commit adds a new command to create an Access Point by the given name from CLI and store its key in the config file.

Also, `connect access-point set` gets more guardrail and logs along with the new command.