### PR TITLE
Remove experimental tags from Autify Connect commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See our official document: https://help.autify.com/docs/autify-command-line-inte
 
 ## `autify connect access-point create`
 
-[Experimental] Create an Autify Connect Access Point
+Create an Autify Connect Access Point
 
 ```
 USAGE
@@ -63,7 +63,7 @@ FLAGS
   --web-workspace-id=<value>  Workspace ID of Autify for Web to which the Access Point belong
 
 DESCRIPTION
-  [Experimental] Create an Autify Connect Access Point
+  Create an Autify Connect Access Point
 
 EXAMPLES
   $ autify connect access-point create --name NAME --web-workspace-id ID
@@ -71,7 +71,7 @@ EXAMPLES
 
 ## `autify connect access-point set`
 
-[Experimental] Set Autify Connect Access Point
+Set Autify Connect Access Point
 
 ```
 USAGE
@@ -81,7 +81,7 @@ FLAGS
   --name=<value>  (required) Name of the Autify Connect Access Point already created
 
 DESCRIPTION
-  [Experimental] Set Autify Connect Access Point
+  Set Autify Connect Access Point
 
 EXAMPLES
   Start interactive setup:
@@ -95,7 +95,7 @@ EXAMPLES
 
 ## `autify connect client install [VERSION]`
 
-[Experimental] Install Autify Connect Client
+Install Autify Connect Client
 
 ```
 USAGE
@@ -105,7 +105,7 @@ ARGUMENTS
   VERSION  [default: v0.6.2] Specify the target version of Autify Connect Client.
 
 DESCRIPTION
-  [Experimental] Install Autify Connect Client
+  Install Autify Connect Client
 
 EXAMPLES
   (Recommended) Install the supported version:
@@ -123,7 +123,7 @@ EXAMPLES
 
 ## `autify connect client start`
 
-[Experimental] Start Autify Connect Client
+Start Autify Connect Client
 
 ```
 USAGE
@@ -138,7 +138,7 @@ FLAGS
                                will use the one configured by `autify connect access-point set`, instead.
 
 DESCRIPTION
-  [Experimental] Start Autify Connect Client
+  Start Autify Connect Client
 
 EXAMPLES
   $ autify connect client start
@@ -658,14 +658,11 @@ FLAGS
   -w, --wait                                         Wait until the test finishes.
   --autify-connect=<value>                           Name of the Autify Connect Access Point (Only for test scenario
                                                      execution.)
-  --autify-connect-client                            [Experimental] Start Autify Connect Client (Only for test scenario
+  --autify-connect-client                            Start Autify Connect Client (Only for test scenario execution.)
+  --autify-connect-client-debug-server-port=<value>  [default: 3000] Port for Autify Connect Client debug server.
+  --autify-connect-client-file-logging               Logging Autify Connect Client log to a file instead of console.
+  --autify-connect-client-verbose                    Verbose output for Autify Connect Client (Only for test scenario
                                                      execution.)
-  --autify-connect-client-debug-server-port=<value>  [Experimental] [default: 3000] Port for Autify Connect Client debug
-                                                     server.
-  --autify-connect-client-file-logging               [Experimental] Logging Autify Connect Client log to a file instead
-                                                     of console.
-  --autify-connect-client-verbose                    [Experimental] Verbose output for Autify Connect Client (Only for
-                                                     test scenario execution.)
   --browser=<value>                                  Browser to run the test
   --device=<value>                                   Device to run the test
   --device-type=<value>                              Device type to run the test

--- a/src/commands/connect/access-point/create.ts
+++ b/src/commands/connect/access-point/create.ts
@@ -7,7 +7,7 @@ import {
 import { get, getOrThrow } from "../../../config";
 
 export default class ConnectAccessPointCreate extends Command {
-  static description = "[Experimental] Create an Autify Connect Access Point";
+  static description = "Create an Autify Connect Access Point";
 
   static examples = [
     "<%= config.bin %> <%= command.id %> --name NAME --web-workspace-id ID",

--- a/src/commands/connect/access-point/set.ts
+++ b/src/commands/connect/access-point/set.ts
@@ -6,7 +6,7 @@ import {
 } from "../../../autify/connect/accessPointConfig";
 
 export default class ConnectAccessPointSet extends Command {
-  static description = "[Experimental] Set Autify Connect Access Point";
+  static description = "Set Autify Connect Access Point";
 
   static examples = [
     "Start interactive setup:\n<%= config.bin %> <%= command.id %> --name=NAME",

--- a/src/commands/connect/client/install.ts
+++ b/src/commands/connect/client/install.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../autify/connect/installClient";
 
 export default class ConnectClientInstall extends Command {
-  static description = "[Experimental] Install Autify Connect Client";
+  static description = "Install Autify Connect Client";
 
   static examples = [
     "(Recommended) Install the supported version:\n<%= config.bin %> <%= command.id %>",

--- a/src/commands/connect/client/start.ts
+++ b/src/commands/connect/client/start.ts
@@ -2,7 +2,7 @@ import { Command, Flags } from "@oclif/core";
 import { ClientManager } from "../../../autify/connect/client-manager/ClientManager";
 
 export default class ConnectClientStart extends Command {
-  static description = "[Experimental] Start Autify Connect Client";
+  static description = "Start Autify Connect Client";
 
   static examples = ["<%= config.bin %> <%= command.id %>"];
 

--- a/src/commands/web/test/run.ts
+++ b/src/commands/web/test/run.ts
@@ -61,22 +61,22 @@ export default class WebTestRun extends Command {
     }),
     "autify-connect-client": Flags.boolean({
       description:
-        "[Experimental] Start Autify Connect Client (Only for test scenario execution.)",
+        "Start Autify Connect Client (Only for test scenario execution.)",
       exclusive: ["autify-connect"],
       dependsOn: ["wait"],
     }),
     "autify-connect-client-verbose": Flags.boolean({
       description:
-        "[Experimental] Verbose output for Autify Connect Client (Only for test scenario execution.)",
+        "Verbose output for Autify Connect Client (Only for test scenario execution.)",
       dependsOn: ["autify-connect-client"],
     }),
     "autify-connect-client-file-logging": Flags.boolean({
       description:
-        "[Experimental] Logging Autify Connect Client log to a file instead of console.",
+        "Logging Autify Connect Client log to a file instead of console.",
       dependsOn: ["autify-connect-client"],
     }),
     "autify-connect-client-debug-server-port": Flags.integer({
-      description: `[Experimental] [default: ${ClientManager.DEFAULT_DEBUG_SERVER_PORT}] Port for Autify Connect Client debug server.`,
+      description: `[default: ${ClientManager.DEFAULT_DEBUG_SERVER_PORT}] Port for Autify Connect Client debug server.`,
       dependsOn: ["autify-connect-client"],
     }),
     os: Flags.string({ description: "OS to run the test" }),


### PR DESCRIPTION
Since we've implemented enough integration tests, better Windows support, and maintainable code based on `xstate`, we'd like to remove the experimental tags from help messages of Autify Connect commands.