### PR TITLE
Revert back timestamp in client console log

### DIFF
--- a/integration-test/__recordings__/web%20test%20run%20--autify-connect-client%20--wait%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Fscenarios%2F91437/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/web%20test%20run%20--autify-connect-client%20--wait%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Fscenarios%2F91437/polly-proxy_3343057686/recording.har
@@ -21,7 +21,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"name\":\"autify-cli-6f38d5df-9c1a-4aef-ae90-47ff09d8c1e7\"}"
+            "text": "{\"name\":\"autify-cli-f1809089-54dc-412c-b077-520ecd7e4c2f\"}"
           },
           "queryString": [],
           "url": "https://app.autify.com/api/v1/projects/743/autify_connect/access_points"
@@ -31,7 +31,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 211,
-            "text": "{\"name\":\"autify-cli-6f38d5df-9c1a-4aef-ae90-47ff09d8c1e7\",\"key\":\"000000000000000000000000000000\",\"last_use\":null,\"creator\":\"riywo\",\"created_at\":\"2022-09-15T18:45:44.857Z\",\"updated_at\":\"2022-09-15T18:45:44.857Z\"}"
+            "text": "{\"name\":\"autify-cli-f1809089-54dc-412c-b077-520ecd7e4c2f\",\"key\":\"000000000000000000000000000000\",\"last_use\":null,\"creator\":\"riywo\",\"created_at\":\"2022-09-15T18:55:34.155Z\",\"updated_at\":\"2022-09-15T18:55:34.155Z\"}"
           },
           "cookies": [],
           "headers": [],
@@ -41,8 +41,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-15T18:45:44.081Z",
-        "time": 836,
+        "startedDateTime": "2022-09-15T18:55:33.512Z",
+        "time": 702,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -50,7 +50,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 836
+          "wait": 702
         }
       },
       {
@@ -76,7 +76,7 @@
           },
           "cookies": [
             {
-              "expires": "2042-09-15T18:45:45.000Z",
+              "expires": "2042-09-15T18:55:34.000Z",
               "httpOnly": true,
               "name": "current_project_id",
               "path": "/",
@@ -91,8 +91,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-15T18:45:44.965Z",
-        "time": 483,
+        "startedDateTime": "2022-09-15T18:55:34.256Z",
+        "time": 490,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -100,11 +100,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 483
+          "wait": 490
         }
       },
       {
-        "_id": "a0fff4a0b503e9c5138da3682a621c1b",
+        "_id": "48fef089f1b9f0f7b1e88ba89a7b8bbc",
         "_order": 0,
         "cache": {},
         "request": {
@@ -117,7 +117,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"capabilities\":[{\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"device_type\":null,\"unsupported\":false}],\"scenarios\":[{\"id\":91437}],\"url_replacements\":[],\"autify_connect\":{\"name\":\"autify-cli-6f38d5df-9c1a-4aef-ae90-47ff09d8c1e7\"}}"
+            "text": "{\"capabilities\":[{\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"device_type\":null,\"unsupported\":false}],\"scenarios\":[{\"id\":91437}],\"url_replacements\":[],\"autify_connect\":{\"name\":\"autify-cli-f1809089-54dc-412c-b077-520ecd7e4c2f\"}}"
           },
           "queryString": [],
           "url": "https://app.autify.com/api/v1/projects/743/execute_scenarios"
@@ -127,7 +127,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 21,
-            "text": "{\"result_id\":1183573}"
+            "text": "{\"result_id\":1183589}"
           },
           "cookies": [],
           "headers": [],
@@ -137,8 +137,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-15T18:45:45.456Z",
-        "time": 910,
+        "startedDateTime": "2022-09-15T18:55:34.754Z",
+        "time": 694,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -146,11 +146,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 910
+          "wait": 694
         }
       },
       {
-        "_id": "9d8c2cc6bcc8ddd42b4cda57eb70c0da",
+        "_id": "3d7b6af099772cac9df1d5382d1c0e34",
         "_order": 0,
         "cache": {},
         "request": {
@@ -161,14 +161,14 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1183573"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1183589"
         },
         "response": {
           "bodySize": 785,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 785,
-            "text": "{\"id\":1183573,\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:46.243Z\",\"updated_at\":\"2022-09-15T18:45:47.251Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400791,\"capability\":{\"id\":370886,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:45:46.191Z\",\"updated_at\":\"2022-09-15T18:45:46.191Z\"},\"test_case_results\":[{\"id\":4140661,\"test_case_id\":91437,\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:47.222Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183573/capabilities/1400791/scenarios/4140661\",\"updated_at\":\"2022-09-15T18:45:47.279Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1183589,\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2022-09-15T18:55:35.357Z\",\"updated_at\":\"2022-09-15T18:55:36.689Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400807,\"capability\":{\"id\":370893,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:55:35.322Z\",\"updated_at\":\"2022-09-15T18:55:35.322Z\"},\"test_case_results\":[{\"id\":4140677,\"test_case_id\":91437,\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2022-09-15T18:55:36.658Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183589/capabilities/1400807/scenarios/4140677\",\"updated_at\":\"2022-09-15T18:55:36.720Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -178,8 +178,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-15T18:45:47.393Z",
-        "time": 503,
+        "startedDateTime": "2022-09-15T18:55:36.475Z",
+        "time": 514,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -187,11 +187,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 503
+          "wait": 514
         }
       },
       {
-        "_id": "9d8c2cc6bcc8ddd42b4cda57eb70c0da",
+        "_id": "3d7b6af099772cac9df1d5382d1c0e34",
         "_order": 1,
         "cache": {},
         "request": {
@@ -202,14 +202,14 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1183573"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1183589"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1183573,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:45:47.966Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:46.243Z\",\"updated_at\":\"2022-09-15T18:45:48.025Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400791,\"capability\":{\"id\":370886,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:45:46.191Z\",\"updated_at\":\"2022-09-15T18:45:46.191Z\"},\"test_case_results\":[{\"id\":4140661,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:45:47.966Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:47.222Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183573/capabilities/1400791/scenarios/4140661\",\"updated_at\":\"2022-09-15T18:45:48.118Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1183589,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:55:37.340Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:55:35.357Z\",\"updated_at\":\"2022-09-15T18:55:37.411Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400807,\"capability\":{\"id\":370893,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:55:35.322Z\",\"updated_at\":\"2022-09-15T18:55:35.322Z\"},\"test_case_results\":[{\"id\":4140677,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:55:37.340Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:55:36.658Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183589/capabilities/1400807/scenarios/4140677\",\"updated_at\":\"2022-09-15T18:55:37.517Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -219,89 +219,7 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-15T18:45:48.392Z",
-        "time": 515,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 515
-        }
-      },
-      {
-        "_id": "9d8c2cc6bcc8ddd42b4cda57eb70c0da",
-        "_order": 2,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 275,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1183573"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1183573,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:45:47.966Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:46.243Z\",\"updated_at\":\"2022-09-15T18:45:48.025Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400791,\"capability\":{\"id\":370886,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:45:46.191Z\",\"updated_at\":\"2022-09-15T18:45:46.191Z\"},\"test_case_results\":[{\"id\":4140661,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:45:47.966Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:47.222Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183573/capabilities/1400791/scenarios/4140661\",\"updated_at\":\"2022-09-15T18:45:48.118Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2022-09-15T18:45:49.394Z",
-        "time": 597,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 597
-        }
-      },
-      {
-        "_id": "9d8c2cc6bcc8ddd42b4cda57eb70c0da",
-        "_order": 3,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 275,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1183573"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1183573,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:45:47.966Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:46.243Z\",\"updated_at\":\"2022-09-15T18:45:48.025Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400791,\"capability\":{\"id\":370886,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:45:46.191Z\",\"updated_at\":\"2022-09-15T18:45:46.191Z\"},\"test_case_results\":[{\"id\":4140661,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:45:47.966Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:47.222Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183573/capabilities/1400791/scenarios/4140661\",\"updated_at\":\"2022-09-15T18:45:48.118Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2022-09-15T18:45:50.395Z",
+        "startedDateTime": "2022-09-15T18:55:37.474Z",
         "time": 496,
         "timings": {
           "blocked": -1,
@@ -314,7 +232,89 @@
         }
       },
       {
-        "_id": "9d8c2cc6bcc8ddd42b4cda57eb70c0da",
+        "_id": "3d7b6af099772cac9df1d5382d1c0e34",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1183589"
+        },
+        "response": {
+          "bodySize": 829,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 829,
+            "text": "{\"id\":1183589,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:55:37.340Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:55:35.357Z\",\"updated_at\":\"2022-09-15T18:55:37.411Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400807,\"capability\":{\"id\":370893,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:55:35.322Z\",\"updated_at\":\"2022-09-15T18:55:35.322Z\"},\"test_case_results\":[{\"id\":4140677,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:55:37.340Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:55:36.658Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183589/capabilities/1400807/scenarios/4140677\",\"updated_at\":\"2022-09-15T18:55:37.517Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-15T18:55:38.475Z",
+        "time": 518,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 518
+        }
+      },
+      {
+        "_id": "3d7b6af099772cac9df1d5382d1c0e34",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1183589"
+        },
+        "response": {
+          "bodySize": 829,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 829,
+            "text": "{\"id\":1183589,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:55:37.340Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:55:35.357Z\",\"updated_at\":\"2022-09-15T18:55:37.411Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400807,\"capability\":{\"id\":370893,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:55:35.322Z\",\"updated_at\":\"2022-09-15T18:55:35.322Z\"},\"test_case_results\":[{\"id\":4140677,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:55:37.340Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:55:36.658Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183589/capabilities/1400807/scenarios/4140677\",\"updated_at\":\"2022-09-15T18:55:37.517Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-15T18:55:39.474Z",
+        "time": 492,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 492
+        }
+      },
+      {
+        "_id": "3d7b6af099772cac9df1d5382d1c0e34",
         "_order": 4,
         "cache": {},
         "request": {
@@ -325,14 +325,14 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1183573"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1183589"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1183573,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:45:47.966Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:46.243Z\",\"updated_at\":\"2022-09-15T18:45:48.025Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400791,\"capability\":{\"id\":370886,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:45:46.191Z\",\"updated_at\":\"2022-09-15T18:45:46.191Z\"},\"test_case_results\":[{\"id\":4140661,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:45:47.966Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:47.222Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183573/capabilities/1400791/scenarios/4140661\",\"updated_at\":\"2022-09-15T18:45:48.118Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1183589,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:55:37.340Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:55:35.357Z\",\"updated_at\":\"2022-09-15T18:55:37.411Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400807,\"capability\":{\"id\":370893,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:55:35.322Z\",\"updated_at\":\"2022-09-15T18:55:35.322Z\"},\"test_case_results\":[{\"id\":4140677,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:55:37.340Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:55:36.658Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183589/capabilities/1400807/scenarios/4140677\",\"updated_at\":\"2022-09-15T18:55:37.517Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -342,8 +342,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-15T18:45:51.395Z",
-        "time": 474,
+        "startedDateTime": "2022-09-15T18:55:40.475Z",
+        "time": 520,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -351,11 +351,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 474
+          "wait": 520
         }
       },
       {
-        "_id": "9d8c2cc6bcc8ddd42b4cda57eb70c0da",
+        "_id": "3d7b6af099772cac9df1d5382d1c0e34",
         "_order": 5,
         "cache": {},
         "request": {
@@ -366,14 +366,14 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1183573"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1183589"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1183573,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:45:47.966Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:46.243Z\",\"updated_at\":\"2022-09-15T18:45:48.025Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400791,\"capability\":{\"id\":370886,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:45:46.191Z\",\"updated_at\":\"2022-09-15T18:45:46.191Z\"},\"test_case_results\":[{\"id\":4140661,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:45:47.966Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:47.222Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183573/capabilities/1400791/scenarios/4140661\",\"updated_at\":\"2022-09-15T18:45:48.118Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1183589,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:55:37.340Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:55:35.357Z\",\"updated_at\":\"2022-09-15T18:55:37.411Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400807,\"capability\":{\"id\":370893,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:55:35.322Z\",\"updated_at\":\"2022-09-15T18:55:35.322Z\"},\"test_case_results\":[{\"id\":4140677,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:55:37.340Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:55:36.658Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183589/capabilities/1400807/scenarios/4140677\",\"updated_at\":\"2022-09-15T18:55:37.517Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -383,8 +383,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-15T18:45:52.396Z",
-        "time": 538,
+        "startedDateTime": "2022-09-15T18:55:41.476Z",
+        "time": 472,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -392,11 +392,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 538
+          "wait": 472
         }
       },
       {
-        "_id": "9d8c2cc6bcc8ddd42b4cda57eb70c0da",
+        "_id": "3d7b6af099772cac9df1d5382d1c0e34",
         "_order": 6,
         "cache": {},
         "request": {
@@ -407,14 +407,14 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1183573"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1183589"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1183573,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:45:47.966Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:46.243Z\",\"updated_at\":\"2022-09-15T18:45:48.025Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400791,\"capability\":{\"id\":370886,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:45:46.191Z\",\"updated_at\":\"2022-09-15T18:45:46.191Z\"},\"test_case_results\":[{\"id\":4140661,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:45:47.966Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:47.222Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183573/capabilities/1400791/scenarios/4140661\",\"updated_at\":\"2022-09-15T18:45:48.118Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1183589,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:55:37.340Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:55:35.357Z\",\"updated_at\":\"2022-09-15T18:55:37.411Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400807,\"capability\":{\"id\":370893,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:55:35.322Z\",\"updated_at\":\"2022-09-15T18:55:35.322Z\"},\"test_case_results\":[{\"id\":4140677,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:55:37.340Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:55:36.658Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183589/capabilities/1400807/scenarios/4140677\",\"updated_at\":\"2022-09-15T18:55:37.517Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -424,8 +424,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-15T18:45:53.396Z",
-        "time": 535,
+        "startedDateTime": "2022-09-15T18:55:42.476Z",
+        "time": 486,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -433,11 +433,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 535
+          "wait": 486
         }
       },
       {
-        "_id": "9d8c2cc6bcc8ddd42b4cda57eb70c0da",
+        "_id": "3d7b6af099772cac9df1d5382d1c0e34",
         "_order": 7,
         "cache": {},
         "request": {
@@ -448,14 +448,14 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1183573"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1183589"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1183573,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:45:47.966Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:46.243Z\",\"updated_at\":\"2022-09-15T18:45:48.025Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400791,\"capability\":{\"id\":370886,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:45:46.191Z\",\"updated_at\":\"2022-09-15T18:45:46.191Z\"},\"test_case_results\":[{\"id\":4140661,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:45:47.966Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:47.222Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183573/capabilities/1400791/scenarios/4140661\",\"updated_at\":\"2022-09-15T18:45:48.118Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1183589,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:55:37.340Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:55:35.357Z\",\"updated_at\":\"2022-09-15T18:55:37.411Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400807,\"capability\":{\"id\":370893,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:55:35.322Z\",\"updated_at\":\"2022-09-15T18:55:35.322Z\"},\"test_case_results\":[{\"id\":4140677,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:55:37.340Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:55:36.658Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183589/capabilities/1400807/scenarios/4140677\",\"updated_at\":\"2022-09-15T18:55:37.517Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -465,8 +465,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-15T18:45:54.396Z",
-        "time": 537,
+        "startedDateTime": "2022-09-15T18:55:43.476Z",
+        "time": 449,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -474,11 +474,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 537
+          "wait": 449
         }
       },
       {
-        "_id": "9d8c2cc6bcc8ddd42b4cda57eb70c0da",
+        "_id": "3d7b6af099772cac9df1d5382d1c0e34",
         "_order": 8,
         "cache": {},
         "request": {
@@ -489,14 +489,14 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1183573"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1183589"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1183573,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:45:47.966Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:46.243Z\",\"updated_at\":\"2022-09-15T18:45:48.025Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400791,\"capability\":{\"id\":370886,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:45:46.191Z\",\"updated_at\":\"2022-09-15T18:45:46.191Z\"},\"test_case_results\":[{\"id\":4140661,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:45:47.966Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:47.222Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183573/capabilities/1400791/scenarios/4140661\",\"updated_at\":\"2022-09-15T18:45:48.118Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1183589,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:55:37.340Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:55:35.357Z\",\"updated_at\":\"2022-09-15T18:55:37.411Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400807,\"capability\":{\"id\":370893,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:55:35.322Z\",\"updated_at\":\"2022-09-15T18:55:35.322Z\"},\"test_case_results\":[{\"id\":4140677,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:55:37.340Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:55:36.658Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183589/capabilities/1400807/scenarios/4140677\",\"updated_at\":\"2022-09-15T18:55:37.517Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -506,8 +506,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-15T18:45:55.396Z",
-        "time": 460,
+        "startedDateTime": "2022-09-15T18:55:44.476Z",
+        "time": 510,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -515,11 +515,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 460
+          "wait": 510
         }
       },
       {
-        "_id": "9d8c2cc6bcc8ddd42b4cda57eb70c0da",
+        "_id": "3d7b6af099772cac9df1d5382d1c0e34",
         "_order": 9,
         "cache": {},
         "request": {
@@ -530,55 +530,14 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1183573"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1183573,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:45:47.966Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:46.243Z\",\"updated_at\":\"2022-09-15T18:45:48.025Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400791,\"capability\":{\"id\":370886,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:45:46.191Z\",\"updated_at\":\"2022-09-15T18:45:46.191Z\"},\"test_case_results\":[{\"id\":4140661,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-15T18:45:47.966Z\",\"finished_at\":null,\"created_at\":\"2022-09-15T18:45:47.222Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183573/capabilities/1400791/scenarios/4140661\",\"updated_at\":\"2022-09-15T18:45:48.118Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2022-09-15T18:45:56.397Z",
-        "time": 460,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 460
-        }
-      },
-      {
-        "_id": "9d8c2cc6bcc8ddd42b4cda57eb70c0da",
-        "_order": 10,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 275,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1183573"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1183589"
         },
         "response": {
           "bodySize": 871,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 871,
-            "text": "{\"id\":1183573,\"status\":\"passed\",\"duration\":6450,\"started_at\":\"2022-09-15T18:45:47.966Z\",\"finished_at\":\"2022-09-15T18:45:54.417Z\",\"created_at\":\"2022-09-15T18:45:46.243Z\",\"updated_at\":\"2022-09-15T18:45:57.343Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400791,\"capability\":{\"id\":370886,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:45:46.191Z\",\"updated_at\":\"2022-09-15T18:45:46.191Z\"},\"test_case_results\":[{\"id\":4140661,\"test_case_id\":91437,\"status\":\"passed\",\"duration\":5189,\"started_at\":\"2022-09-15T18:45:49.228Z\",\"finished_at\":\"2022-09-15T18:45:54.417Z\",\"created_at\":\"2022-09-15T18:45:47.222Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183573/capabilities/1400791/scenarios/4140661\",\"updated_at\":\"2022-09-15T18:45:57.182Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1183589,\"status\":\"passed\",\"duration\":5226,\"started_at\":\"2022-09-15T18:55:37.340Z\",\"finished_at\":\"2022-09-15T18:55:42.567Z\",\"created_at\":\"2022-09-15T18:55:35.357Z\",\"updated_at\":\"2022-09-15T18:55:45.423Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1400807,\"capability\":{\"id\":370893,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":null,\"created_at\":\"2022-09-15T18:55:35.322Z\",\"updated_at\":\"2022-09-15T18:55:35.322Z\"},\"test_case_results\":[{\"id\":4140677,\"test_case_id\":91437,\"status\":\"passed\",\"duration\":3992,\"started_at\":\"2022-09-15T18:55:38.575Z\",\"finished_at\":\"2022-09-15T18:55:42.567Z\",\"created_at\":\"2022-09-15T18:55:36.658Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1183589/capabilities/1400807/scenarios/4140677\",\"updated_at\":\"2022-09-15T18:55:45.303Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -588,8 +547,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-15T18:45:57.397Z",
-        "time": 491,
+        "startedDateTime": "2022-09-15T18:55:45.477Z",
+        "time": 503,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -597,7 +556,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 491
+          "wait": 503
         }
       },
       {
@@ -614,7 +573,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"name\":\"autify-cli-6f38d5df-9c1a-4aef-ae90-47ff09d8c1e7\"}"
+            "text": "{\"name\":\"autify-cli-f1809089-54dc-412c-b077-520ecd7e4c2f\"}"
           },
           "queryString": [],
           "url": "https://app.autify.com/api/v1/projects/743/autify_connect/access_points"
@@ -634,8 +593,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-09-15T18:45:57.899Z",
-        "time": 532,
+        "startedDateTime": "2022-09-15T18:55:45.993Z",
+        "time": 525,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -643,7 +602,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 532
+          "wait": 525
         }
       }
     ],

--- a/integration-test/__snapshots__/golden/webTestRunAutifyConnectClient.test.js.snap
+++ b/integration-test/__snapshots__/golden/webTestRunAutifyConnectClient.test.js.snap
@@ -5,16 +5,16 @@ Object {
   "stderr": "",
   "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
 [HPM] Proxy created: /  -> https://mobile-app.autify.com
-[Autify Connect Manager]  info	Ephemeral Access Point was created: autify-cli-6f38d5df-9c1a-4aef-ae90-47ff09d8c1e7
+[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Ephemeral Access Point was created: autify-cli-f1809089-54dc-412c-b077-520ecd7e4c2f
 Starting Autify Connect Client...
-[Autify Connect Manager]  info	Starting Autify Connect Client (accessPoint: autify-cli-6f38d5df-9c1a-4aef-ae90-47ff09d8c1e7, debugServerPort: <random>, path: /path/to/autifyconnect-fake, version: Autify Connect version v0.6.2, build 0913a76)
+[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Starting Autify Connect Client (accessPoint: autify-cli-f1809089-54dc-412c-b077-520ecd7e4c2f, debugServerPort: <random>, path: /path/to/autifyconnect-fake, version: Autify Connect version v0.6.2, build 0913a76)
 Waiting until Autify Connect Client is ready...
-[Autify Connect Client]   info	start serving a debug server on http://localhost:<random>
-[Autify Connect Client]   info	Starting to establish a secure connection with the Autify connect server. Your session ID is \\"fake\\".
-[Autify Connect Client]   info	Successfully connected!
+[Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	start serving a debug server on http://localhost:<random>
+[Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	Starting to establish a secure connection with the Autify connect server. Your session ID is \\"fake\\".
+[Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	Successfully connected!
 Autify Connect Client is ready!
-✅ Successfully started: https://app.autify.com/projects/743/results/1183573 (Capability is Linux Chrome 104.0)
-🕐 Waiting for the test result: https://app.autify.com/projects/743/results/1183573
+✅ Successfully started: https://app.autify.com/projects/743/results/1183589 (Capability is Linux Chrome 104.0)
+🕐 Waiting for the test result: https://app.autify.com/projects/743/results/1183589
 [HH:MM:SS] Waiting... (timeout: 300 s) [started]
 [HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
@@ -25,15 +25,14 @@ Autify Connect Client is ready!
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 👍 Passed , TestCases: 👍 Passed 
 [HH:MM:SS] Waiting... (timeout: 300 s) [completed]
-✅ Test passed!: https://app.autify.com/projects/743/results/1183573
+✅ Test passed!: https://app.autify.com/projects/743/results/1183589
 Waiting until Autify Connect Client exits...
-[Autify Connect Client]   info	Interrupt received.
-[Autify Connect Client]   info	Shutdown completed.
-[Autify Connect Manager]  info	Ephemeral Access Point was deleted: autify-cli-6f38d5df-9c1a-4aef-ae90-47ff09d8c1e7
-[Autify Connect Manager]  info	Autify Connect Client exited (code: 0, signal: null)
+[Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	Interrupt received.
+[Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	Shutdown completed.
+[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Ephemeral Access Point was deleted: autify-cli-f1809089-54dc-412c-b077-520ecd7e4c2f
+[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Autify Connect Client exited (code: 0, signal: null)
 Autify Connect Client exited.
 [HPM] server close signal received: closing proxy server
 ",

--- a/src/autify/connect/client-manager/Logger.ts
+++ b/src/autify/connect/client-manager/Logger.ts
@@ -18,8 +18,10 @@ type ClientLog = Readonly<{
 const logFormatConsole = (prefix: string) =>
   format.combine(
     format.colorize(),
+    format.timestamp(),
     format.printf(
-      ({ level, message }) => `${prefix.padEnd(25)} ${level}\t${message}`
+      ({ timestamp, level, message }) =>
+        `${prefix.padEnd(25)} ${timestamp}\t${level}\t${message}`
     )
   );
 


### PR DESCRIPTION
Previously we removed timestamp from console log for client and manager, but it's useful to see the behavior with timestamp.

This commit reverts it back.