### PR TITLE
Upload shell installer to versions

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -66,6 +66,17 @@ jobs:
         with:
           target: npm
 
+  shell:
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: ./.github/actions/upload
+        with:
+          target: shell
+
   # Not supported yet: https://github.com/oclif/oclif/issues/887
   #deb:
   #  runs-on: 'ubuntu-latest'


### PR DESCRIPTION
To support version lock in other integrations, we should upload shell installer for each specific version.