### PR TITLE
Support Windows by CI/CD shell installer

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -73,8 +73,19 @@ jobs:
   shell:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        target: [standalone-shell, cicd-shell]
+        include:
+          - os: ubuntu-latest
+            target: standalone-shell
+          - os: ubuntu-latest
+            target: cicd-shell
+          - os: macos-latest
+            target: standalone-shell
+          - os: macos-latest
+            target: cicd-shell
+          # - os: windows-latest
+          #  target: standalone-shell
+          - os: windows-latest
+            target: cicd-shell
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/install-cicd.bash
+++ b/install-cicd.bash
@@ -5,10 +5,12 @@ echoerr() { echo "\$@" 1>&2; }
 
 if [ "$(uname)" == "Darwin" ]; then
   OS=darwin
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+elif [ "$(uname -s | cut -c 1-5)" == "Linux" ]; then
   OS=linux
+elif [ "$(uname -s | cut -c 1-5)" == "MINGW" ]; then
+  OS=windows
 else
-  echoerr "This installer is only supported on Linux and macOS"
+  echoerr "Unsupported os: $(uname)"
   exit 1
 fi
 
@@ -30,28 +32,36 @@ AUTIFY_S3_BUCKET=REPLACE
 AUTIFY_S3_PREFIX=REPLACE
 
 WORKSPACE="$(pwd)"
-rm -fr ./autify
-mkdir -p ./autify/bin
-mkdir -p ./autify/lib
-cd ./autify/lib
+rm -fr "$WORKSPACE/autify"
+mkdir "$WORKSPACE/autify"
 
-if [ $(command -v xz) ]; then
-  TAR_EXT="tar.xz"
-  TAR_ARGS="xJ"
+if [ "$OS" == "windows" ]; then
+  URL=https://$AUTIFY_S3_BUCKET.s3.amazonaws.com/$AUTIFY_S3_PREFIX-$ARCH.exe
+  EXE_FILE="$WORKSPACE/autify/installer.exe"
+  curl "$URL" > "$EXE_FILE"
+  cmd.exe /C "$(cygpath -w "$EXE_FILE") /S /D=$(cygpath -w "$WORKSPACE/autify")"
 else
-  TAR_EXT="tar.gz"
-  TAR_ARGS="xz"
-fi
+  mkdir "$WORKSPACE/autify/bin"
+  mkdir "$WORKSPACE/autify/lib"
+  cd "$WORKSPACE/autify/lib"
 
-URL=https://$AUTIFY_S3_BUCKET.s3.amazonaws.com/$AUTIFY_S3_PREFIX-$OS-$ARCH.$TAR_EXT
-echo "Installing CLI from $URL"
-if [ $(command -v curl) ]; then
-  curl "$URL" | tar "$TAR_ARGS"
-else
-  wget -O- "$URL" | tar "$TAR_ARGS"
+  if [ "$(command -v xz)" ]; then
+    TAR_EXT="tar.xz"
+    TAR_ARGS="xJ"
+  else
+    TAR_EXT="tar.gz"
+    TAR_ARGS="xz"
+  fi
+  URL=https://$AUTIFY_S3_BUCKET.s3.amazonaws.com/$AUTIFY_S3_PREFIX-$OS-$ARCH.$TAR_EXT
+  echo "Installing CLI from $URL"
+  if [ "$(command -v curl)" ]; then
+    curl "$URL" | tar "$TAR_ARGS"
+  else
+    wget -O- "$URL" | tar "$TAR_ARGS"
+  fi
+
+  ln -s "$WORKSPACE/autify/lib/autify/bin/autify" "$WORKSPACE/autify/bin/autify"
 fi
 
 cd "$WORKSPACE"
-ln -s "$WORKSPACE/autify/lib/autify/bin/autify" "$WORKSPACE/autify/bin/autify"
-
 "$WORKSPACE/autify/bin/autify" --version


### PR DESCRIPTION
Most of CI/CD providers support Windows with bash so that we should support them by CI/CD shell installer as well.