### PR TITLE
Support integration test installing by CI/CD installer

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -70,22 +70,13 @@ jobs:
           AUTIFY_CONNECT_CLIENT_MODE: "fake"
       - run: npm run test:integration
 
-  shell:
+  standalone-shell:
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-            target: standalone-shell
-          - os: ubuntu-latest
-            target: cicd-shell
-          - os: macos-latest
-            target: standalone-shell
-          - os: macos-latest
-            target: cicd-shell
-          # - os: windows-latest
-          #  target: standalone-shell
-          - os: windows-latest
-            target: cicd-shell
+        os:
+          - ubuntu-latest
+          - macos-latest
+          # - windows-latest
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -96,13 +87,40 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/install
         with:
-          target: ${{ matrix.target }}
+          target: standalone-shell
       - run: echo test | autify web auth login
       - run: echo test | autify mobile auth login
       - run: autify connect client install
         env:
           AUTIFY_CONNECT_CLIENT_MODE: "fake"
       - run: npm run test:integration
+
+  cicd-shell:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+      fail-fast: false
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: ./.github/actions/install
+        with:
+          target: cicd-shell
+        env:
+          AUTIFY_CLI_INTEGRATION_TEST_INSTALL: 1
+      - run: echo test | autify web auth login
+      - run: echo test | autify mobile auth login
+      - run: autify connect client install
+        env:
+          AUTIFY_CONNECT_CLIENT_MODE: "fake"
+      - run: autify-cli-integration-test
 
   brew:
     strategy:

--- a/install-cicd.bash
+++ b/install-cicd.bash
@@ -3,6 +3,21 @@ set -e
 
 echoerr() { echo "\$@" 1>&2; }
 
+AUTIFY_CLI_VERSION=REPLACE
+AUTIFY_S3_BUCKET=REPLACE
+AUTIFY_S3_PREFIX=REPLACE
+
+WORKSPACE="$(pwd)"
+AUTIFY_DIR="$WORKSPACE/autify"
+AUTIFY_PATH="$AUTIFY_DIR/path" # Required PATHs to use the installed commands.
+
+if [ -n "$AUTIFY_CLI_INSTALL_USE_CACHE" ] && [ -d "$AUTIFY_DIR" ]; then
+  echo "$AUTIFY_DIR exists. Reuse it as cache."
+  exit
+fi
+rm -fr "$AUTIFY_DIR"
+mkdir "$AUTIFY_DIR"
+
 if [ "$(uname)" == "Darwin" ]; then
   OS=darwin
 elif [ "$(uname -s | cut -c 1-5)" == "Linux" ]; then
@@ -28,23 +43,17 @@ else
   exit 1
 fi
 
-AUTIFY_S3_BUCKET=REPLACE
-AUTIFY_S3_PREFIX=REPLACE
-
-WORKSPACE="$(pwd)"
-rm -fr "$WORKSPACE/autify"
-mkdir "$WORKSPACE/autify"
-
 if [ "$OS" == "windows" ]; then
-  URL=https://$AUTIFY_S3_BUCKET.s3.amazonaws.com/$AUTIFY_S3_PREFIX-$ARCH.exe
-  EXE_FILE="$WORKSPACE/autify/installer.exe"
+  URL="https://$AUTIFY_S3_BUCKET.s3.amazonaws.com/$AUTIFY_S3_PREFIX-$ARCH.exe"
+  echo "Installing CLI from $URL"
+  EXE_FILE="$AUTIFY_DIR/installer.exe"
   curl "$URL" > "$EXE_FILE"
-  cmd.exe /C "$(cygpath -w "$EXE_FILE") /S /D=$(cygpath -w "$WORKSPACE/autify")"
+  cmd.exe /C "$(cygpath -w "$EXE_FILE") /S /D=$(cygpath -w "$AUTIFY_DIR")"
+  cygpath -w "$AUTIFY_DIR/bin" >> "$AUTIFY_PATH"
 else
-  mkdir "$WORKSPACE/autify/bin"
-  mkdir "$WORKSPACE/autify/lib"
-  cd "$WORKSPACE/autify/lib"
-
+  mkdir "$AUTIFY_DIR/bin"
+  mkdir "$AUTIFY_DIR/lib"
+  cd "$AUTIFY_DIR/lib"
   if [ "$(command -v xz)" ]; then
     TAR_EXT="tar.xz"
     TAR_ARGS="xJ"
@@ -52,7 +61,7 @@ else
     TAR_EXT="tar.gz"
     TAR_ARGS="xz"
   fi
-  URL=https://$AUTIFY_S3_BUCKET.s3.amazonaws.com/$AUTIFY_S3_PREFIX-$OS-$ARCH.$TAR_EXT
+  URL="https://$AUTIFY_S3_BUCKET.s3.amazonaws.com/$AUTIFY_S3_PREFIX-$OS-$ARCH.$TAR_EXT"
   echo "Installing CLI from $URL"
   if [ "$(command -v curl)" ]; then
     curl "$URL" | tar "$TAR_ARGS"
@@ -60,8 +69,31 @@ else
     wget -O- "$URL" | tar "$TAR_ARGS"
   fi
 
-  ln -s "$WORKSPACE/autify/lib/autify/bin/autify" "$WORKSPACE/autify/bin/autify"
+  ln -s "$AUTIFY_DIR/lib/autify/bin/autify" "$AUTIFY_DIR/bin/autify"
+  echo "$AUTIFY_DIR/bin" >> "$AUTIFY_PATH"
 fi
 
 cd "$WORKSPACE"
-"$WORKSPACE/autify/bin/autify" --version
+"$AUTIFY_DIR/bin/autify" --version
+
+if [ -n "$AUTIFY_CLI_INTEGRATION_TEST_INSTALL" ]; then
+  file_prefix=$(basename "$AUTIFY_S3_PREFIX")
+  dir_prefix=$(dirname "$AUTIFY_S3_PREFIX")
+  if [ "$file_prefix" == "autify-" ]; then
+    # channel
+    package="autifyhq-autify-cli-integration-test.tgz"
+  else
+    # version
+    package="autifyhq-autify-cli-integration-test-$AUTIFY_CLI_VERSION.tgz"
+  fi
+  package_url="https://$AUTIFY_S3_BUCKET.s3.amazonaws.com/${dir_prefix}/${package}"
+
+  cd "$AUTIFY_DIR"
+  echo "Installing autify-cli-integration-test package from $package_url"
+  npm install "$package_url"
+  if [ "$OS" == "windows" ]; then
+    cygpath -w "$AUTIFY_DIR/node_modules/.bin" >> "$AUTIFY_PATH"
+  else
+    echo "$AUTIFY_DIR/node_modules/.bin" >> "$AUTIFY_PATH"
+  fi
+fi


### PR DESCRIPTION
To integration test for CI/CD integrations reliable, the CI/CD shell installer should have ability to install the same version of integration package as well.