### PR TITLE
Workaround terminate error of `autifyconnect`

### DIFF
--- a/integration-test/src/test/helpers/execAutifyCli.ts
+++ b/integration-test/src/test/helpers/execAutifyCli.ts
@@ -20,6 +20,7 @@ const normalize = (stdout: string) =>
       /debug server on http:\/\/localhost:\d+/g,
       "debug server on http://localhost:<random>"
     )
+    .replace(/.+Ignoring terminate error:.+\n/, "") // TODO: Remove once autifyconnect is fixed.
     .replace(/Your session ID is "[^"]+"/, 'Your session ID is "fake"');
 
 export const execAutifyCli = async (


### PR DESCRIPTION
`autifyconnect` 0.6.2 has a race condition when calling `POST /terminate` of the debug server. This has been fixed but the patch hasn't been released.

This commit is just a workaround until the newer `autifyconnect` is released.