### PR TITLE
Run CI/CD integration tests

### DIFF
--- a/.github/workflows/cicd-tests.yml
+++ b/.github/workflows/cicd-tests.yml
@@ -1,0 +1,74 @@
+name: CI/CD integration tests
+
+on:
+  workflow_call:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  get:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: ./.github/actions/setup
+      - id: run
+        run: npm run release get-installer-url
+    outputs:
+      installer-url: ${{ steps.run.outputs.installer-url }}
+
+  github-actions:
+    needs: [get]
+    runs-on: ubuntu-latest
+    env:
+      AUTIFY_CLI_INTEGRATION_TEST_INSTALL: 1
+      AUTIFY_TEST_WAIT_INTERVAL_SECOND: 0
+      AUTIFY_CONNECT_CLIENT_MODE: fake
+    steps:
+      - uses: actions/setup-node@v3
+
+      - id: web-test-run
+        uses: autifyhq/actions-web-test-run@main # TODO: Use v1
+        with:
+          access-token: token
+          autify-path: autify-with-proxy
+          autify-cli-installer-url: ${{ needs.get.outputs.installer-url }}
+          autify-test-url: https://app.autify.com/projects/0000/scenarios/0000
+      - run: test "${{ steps.web-test-run.outputs.exit-code }}" = 0
+      - run: echo "${{ steps.web-test-run.outputs.log }}" | grep "Successfully started"
+      - run: echo "${{ steps.web-test-run.outputs.result-url }}" | grep -E 'https://app.autify.com/projects/[[:digit:]]+/'
+
+      - id: web-test-run-wait
+        uses: autifyhq/actions-web-test-run@main # TODO: Use v1
+        with:
+          access-token: token
+          autify-path: autify-with-proxy
+          autify-cli-installer-url: ${{ needs.get.outputs.installer-url }}
+          autify-test-url: https://app.autify.com/projects/0000/scenarios/0000
+          wait: true
+      - run: test "${{ steps.web-test-run-wait.outputs.exit-code }}" = 0
+      - run: echo "${{ steps.web-test-run-wait.outputs.log }}" | grep "Test passed!"
+      - run: echo "${{ steps.web-test-run-wait.outputs.result-url }}" | grep -E 'https://app.autify.com/projects/[[:digit:]]+/'
+
+      - id: web-test-run-wait-autify-connect-client
+        uses: autifyhq/actions-web-test-run@main # TODO: Use v1
+        with:
+          access-token: token
+          autify-path: autify-with-proxy
+          autify-cli-installer-url: ${{ needs.get.outputs.installer-url }}
+          autify-test-url: https://app.autify.com/projects/0000/scenarios/0000
+          wait: true
+          autify-connect-client: true
+      - run: test "${{ steps.web-test-run-wait-autify-connect-client.outputs.exit-code }}" = 0
+      - run: echo "${{ steps.web-test-run-wait-autify-connect-client.outputs.log }}" | grep "Autify Connect Client is ready!"
+      - run: echo "${{ steps.web-test-run-wait-autify-connect-client.outputs.log }}" | grep "Test passed!"
+      - run: echo "${{ steps.web-test-run-wait-autify-connect-client.outputs.result-url }}" | grep -E 'https://app.autify.com/projects/[[:digit:]]+/'
+
+  # circleci-orbs:
+
+  # jenkins-plugin:
+
+  # bitrise-steps:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -20,8 +20,12 @@ jobs:
     needs: [upload]
     uses: ./.github/workflows/integration-tests.yml
 
+  cicd-tests:
+    needs: [upload]
+    uses: ./.github/workflows/cicd-tests.yml
+
   approved:
-    needs: [integration-tests]
+    needs: [integration-tests, cicd-tests]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -20,8 +20,12 @@ jobs:
     needs: [upload]
     uses: ./.github/workflows/integration-tests.yml
 
+  cicd-tests:
+    needs: [upload]
+    uses: ./.github/workflows/cicd-tests.yml
+
   promote:
-    needs: [integration-tests]
+    needs: [integration-tests, cicd-tests]
     uses: ./.github/workflows/promote.yml
     secrets:
       BOT_APP_ID: ${{ secrets.BOT_APP_ID }}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -461,6 +461,15 @@ const validateCommand = (args: string[]) => {
     throw new Error(`Invalid channel (${channel}) for branch: ${targetBranch}`);
 };
 
+const setOutput = (name: string, value: string) => {
+  console.log(`::set-output name=${name}::${value}`);
+};
+
+const getInstallerUrlCommand = () => {
+  const url = `https://${bucket}.s3.amazonaws.com/${s3KeyPrefix}/install-cicd.bash`;
+  setOutput("installer-url", url);
+};
+
 const main = () => {
   if (process.argv.length < 3) {
     fail("Usage: ts-node ./scripts/release.ts COMMAND ARGS");
@@ -511,6 +520,11 @@ const main = () => {
 
     case "validate": {
       validateCommand(args);
+      break;
+    }
+
+    case "get-installer-url": {
+      getInstallerUrlCommand();
       break;
     }
 


### PR DESCRIPTION
To ensure the new change can work with the current CI/CD integrations, we add a new workflow for CI/CD integration test.

#92

First, GitHub Actions.