### PR TITLE
Fix `mobile build upload` for larger files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "integration-test"
       ],
       "dependencies": {
-        "@autifyhq/autify-sdk": "^0.4.0",
+        "@autifyhq/autify-sdk": "^0.5.0",
         "@oclif/core": "^1",
         "@oclif/errors": "^1.3.5",
         "@oclif/plugin-help": "^5",
@@ -131,9 +131,9 @@
       "link": true
     },
     "node_modules/@autifyhq/autify-sdk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@autifyhq/autify-sdk/-/autify-sdk-0.4.0.tgz",
-      "integrity": "sha512-w/oFH5fyc46oE/kzLOkDpyfAE1bKgml7m0mA5+qA2b7Ly1ENDSeY3FrZ+HJ9JFf9M1qw1x4ZGJYQpBQHpswlcQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@autifyhq/autify-sdk/-/autify-sdk-0.5.0.tgz",
+      "integrity": "sha512-qvomJLCictbEIh9Gk4Cof3j9/lS2QEByGXalNK1qRSepnZtiXp+R24+FGyWB+IvLS6Y1/eLFtANb16kpB2Wx3w==",
       "dependencies": {
         "axios": "^0.27.2",
         "axios-logger": "^2.6.1",
@@ -13813,9 +13813,9 @@
       }
     },
     "@autifyhq/autify-sdk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@autifyhq/autify-sdk/-/autify-sdk-0.4.0.tgz",
-      "integrity": "sha512-w/oFH5fyc46oE/kzLOkDpyfAE1bKgml7m0mA5+qA2b7Ly1ENDSeY3FrZ+HJ9JFf9M1qw1x4ZGJYQpBQHpswlcQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@autifyhq/autify-sdk/-/autify-sdk-0.5.0.tgz",
+      "integrity": "sha512-qvomJLCictbEIh9Gk4Cof3j9/lS2QEByGXalNK1qRSepnZtiXp+R24+FGyWB+IvLS6Y1/eLFtANb16kpB2Wx3w==",
       "requires": {
         "axios": "^0.27.2",
         "axios-logger": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "/oclif.manifest.json"
   ],
   "dependencies": {
-    "@autifyhq/autify-sdk": "^0.4.0",
+    "@autifyhq/autify-sdk": "^0.5.0",
     "@oclif/core": "^1",
     "@oclif/errors": "^1.3.5",
     "@oclif/plugin-help": "^5",


### PR DESCRIPTION
`autify-sdk-js` 0.4.0 doesn't work with larger files. 0.5.0 fixes the issue and now the user can upload any size of file.

Previous error:
```
RangeError: Invalid array length
    at Buffer.toJSON (node:buffer:1100:15)
    at JSON.stringify (<anonymous>)
    at StringBuilder.makeData (/opt/homebrew/Cellar/autify-cli/0.10.1/lib/client/0.11.0-beta.0-ab2b25b/node_modules/axios-logger/lib/common/string-builder.js:82:56)
    at requestLogger (/opt/homebrew/Cellar/autify-cli/0.10.1/lib/client/0.11.0-beta.0-ab2b25b/node_modules/axios-logger/lib/logger/request.js:25:169)
```

Fix of `autify-sdk-js`: https://github.com/autifyhq/autify-sdk-js/pull/81