### PR TITLE
Removing ubuntu-latest from brew integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -130,7 +130,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          # `brew` has been removed from ubuntu-latest?
+          # - os: ubuntu-latest
           - os: macos-latest
       fail-fast: false
 


### PR DESCRIPTION
It looks like GitHub has removed `brew` from `ubuntu-lates`.

https://github.com/autifyhq/autify-cli/actions/runs/3132660914/jobs/5085265698#step:17:146