### PR TITLE
Add `AUTIFY_CLI_USER_AGENT_SUFFIX`

### DIFF
--- a/scripts/generate-api-commands.ts
+++ b/scripts/generate-api-commands.ts
@@ -19,6 +19,7 @@ const kebabize = (str: string) =>
   );
 
 const writeCommandSource = (service: string, apiMethod: MethodDeclaration) => {
+  const Service = pascallize(service);
   const commandClassName =
     pascallize(service) + "Api" + pascallize(apiMethod.getName());
   const jsDoc = apiMethod.getJsDocs()[0];
@@ -53,7 +54,6 @@ const writeCommandSource = (service: string, apiMethod: MethodDeclaration) => {
 
   const flagsString = flags.join("\n");
   const argsString = args.join(", ");
-  const clientClass = `${pascallize(service)}Client`;
   project
     .createSourceFile(
       `./src/commands/${service}/api/${kebabize(apiMethod.getName())}.ts`,
@@ -62,8 +62,7 @@ const writeCommandSource = (service: string, apiMethod: MethodDeclaration) => {
           .write(
             `
 import {Command, Flags} from '@oclif/core'
-import {${clientClass} as Client} from '@autifyhq/autify-sdk'
-import {get, getOrThrow} from '../../../config'
+import {get${Service}Client} from '../../../autify/${service}/get${Service}Client'
 
 export default class ${commandClassName} extends Command {
   static description = '${description.trim()}'
@@ -79,9 +78,7 @@ ${flagsString}
   public async run(): Promise<void> {
     const {flags} = await this.parse(${commandClassName})
     const {configDir, userAgent} = this.config
-    const accessToken = getOrThrow(configDir, 'AUTIFY_${service.toUpperCase()}_ACCESS_TOKEN')
-    const basePath = get(configDir, 'AUTIFY_${service.toUpperCase()}_BASE_PATH')
-    const client = new Client(accessToken, {basePath, userAgent})
+    const client = get${Service}Client(configDir, userAgent);
     const res = await client.${apiMethod.getName()}(${argsString})
     console.log(JSON.stringify(res.data, null, 2))
   }

--- a/src/autify/connect/client-manager/ClientManager.ts
+++ b/src/autify/connect/client-manager/ClientManager.ts
@@ -5,7 +5,7 @@ import { ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { env } from "node:process";
 import { EventEmitter } from "node:stream";
 import { Logger } from "winston";
-import { get, getOrThrow } from "../../../config";
+import { get } from "../../../config";
 import {
   AccessPoint,
   createEphemeralAccessPointForWeb,
@@ -29,6 +29,7 @@ import {
 import { join } from "node:path";
 import TypedEmitter from "typed-emitter";
 import getPort from "get-port";
+import { getWebClient } from "../../web/getWebClient";
 
 export type ClientEvents = TypedEmitter<{
   log: (msg: string) => void;
@@ -65,9 +66,7 @@ export class ClientManager {
   ): Promise<ClientManager> {
     if (options.webWorkspaceId) {
       const { configDir, userAgent, webWorkspaceId } = options;
-      const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
-      const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
-      const client = new WebClient(accessToken, { basePath, userAgent });
+      const client = getWebClient(configDir, userAgent);
       return this.createWithEphemeralAccessPointForWeb(
         client,
         webWorkspaceId,

--- a/src/autify/mobile/getMobileClient.ts
+++ b/src/autify/mobile/getMobileClient.ts
@@ -1,0 +1,16 @@
+/* eslint-disable unicorn/filename-case */
+import { MobileClient } from "@autifyhq/autify-sdk";
+import { get, getOrThrow } from "../../config";
+
+export const getMobileClient = (
+  configDir: string,
+  userAgent: string
+): MobileClient => {
+  const accessToken = getOrThrow(configDir, "AUTIFY_MOBILE_ACCESS_TOKEN");
+  const basePath = get(configDir, "AUTIFY_MOBILE_BASE_PATH");
+  const userAgentSuffix = get(configDir, "AUTIFY_CLI_USER_AGENT_SUFFIX") ?? "";
+  return new MobileClient(accessToken, {
+    basePath,
+    userAgent: `${userAgent} ${userAgentSuffix}`.trim(),
+  });
+};

--- a/src/autify/web/getWebClient.ts
+++ b/src/autify/web/getWebClient.ts
@@ -1,0 +1,16 @@
+/* eslint-disable unicorn/filename-case */
+import { WebClient } from "@autifyhq/autify-sdk";
+import { get, getOrThrow } from "../../config";
+
+export const getWebClient = (
+  configDir: string,
+  userAgent: string
+): WebClient => {
+  const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
+  const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
+  const userAgentSuffix = get(configDir, "AUTIFY_CLI_USER_AGENT_SUFFIX") ?? "";
+  return new WebClient(accessToken, {
+    basePath,
+    userAgent: `${userAgent} ${userAgentSuffix}`.trim(),
+  });
+};

--- a/src/commands/connect/access-point/create.ts
+++ b/src/commands/connect/access-point/create.ts
@@ -1,10 +1,9 @@
-import { WebClient } from "@autifyhq/autify-sdk";
 import { Command, Flags } from "@oclif/core";
 import {
   confirmOverwriteAccessPoint,
   saveAccessPoint,
 } from "../../../autify/connect/accessPointConfig";
-import { get, getOrThrow } from "../../../config";
+import { getWebClient } from "../../../autify/web/getWebClient";
 
 export default class ConnectAccessPointCreate extends Command {
   static description = "Create an Autify Connect Access Point";
@@ -33,9 +32,7 @@ export default class ConnectAccessPointCreate extends Command {
     await confirmOverwriteAccessPoint(configDir);
     const { name, "web-workspace-id": webWorkspaceId } = flags;
     if (webWorkspaceId) {
-      const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
-      const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
-      const client = new WebClient(accessToken, { basePath, userAgent });
+      const client = getWebClient(configDir, userAgent);
       const response = await client.createAccessPoint(webWorkspaceId, {
         name,
       });

--- a/src/commands/mobile/api/describe-test-result.ts
+++ b/src/commands/mobile/api/describe-test-result.ts
@@ -1,6 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import { MobileClient as Client } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
+import { getMobileClient } from "../../../autify/mobile/getMobileClient";
 
 export default class MobileApiDescribeTestResult extends Command {
   static description = "Get a test result.";
@@ -19,9 +18,7 @@ export default class MobileApiDescribeTestResult extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(MobileApiDescribeTestResult);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_MOBILE_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_MOBILE_BASE_PATH");
-    const client = new Client(accessToken, { basePath, userAgent });
+    const client = getMobileClient(configDir, userAgent);
     const res = await client.describeTestResult(flags["project-id"], flags.id);
     console.log(JSON.stringify(res.data, null, 2));
   }

--- a/src/commands/mobile/api/list-test-results.ts
+++ b/src/commands/mobile/api/list-test-results.ts
@@ -1,6 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import { MobileClient as Client } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
+import { getMobileClient } from "../../../autify/mobile/getMobileClient";
 
 export default class MobileApiListTestResults extends Command {
   static description = "List test results.";
@@ -30,9 +29,7 @@ export default class MobileApiListTestResults extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(MobileApiListTestResults);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_MOBILE_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_MOBILE_BASE_PATH");
-    const client = new Client(accessToken, { basePath, userAgent });
+    const client = getMobileClient(configDir, userAgent);
     const res = await client.listTestResults(
       flags["project-id"],
       flags.page,

--- a/src/commands/mobile/api/run-test-plan.ts
+++ b/src/commands/mobile/api/run-test-plan.ts
@@ -1,6 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import { MobileClient as Client } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
+import { getMobileClient } from "../../../autify/mobile/getMobileClient";
 
 export default class MobileApiRunTestPlan extends Command {
   static description = "Run a test plan";
@@ -21,9 +20,7 @@ export default class MobileApiRunTestPlan extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(MobileApiRunTestPlan);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_MOBILE_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_MOBILE_BASE_PATH");
-    const client = new Client(accessToken, { basePath, userAgent });
+    const client = getMobileClient(configDir, userAgent);
     const res = await client.runTestPlan(
       flags["test-plan-id"],
       JSON.parse(flags["run-test-plan-request"])

--- a/src/commands/mobile/api/upload-build.ts
+++ b/src/commands/mobile/api/upload-build.ts
@@ -1,6 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import { MobileClient as Client } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
+import { getMobileClient } from "../../../autify/mobile/getMobileClient";
 
 export default class MobileApiUploadBuild extends Command {
   static description = "Upload the build file.";
@@ -18,9 +17,7 @@ export default class MobileApiUploadBuild extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(MobileApiUploadBuild);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_MOBILE_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_MOBILE_BASE_PATH");
-    const client = new Client(accessToken, { basePath, userAgent });
+    const client = getMobileClient(configDir, userAgent);
     const res = await client.uploadBuild(flags["project-id"], flags.file);
     console.log(JSON.stringify(res.data, null, 2));
   }

--- a/src/commands/mobile/build/upload.ts
+++ b/src/commands/mobile/build/upload.ts
@@ -1,9 +1,8 @@
-import { MobileClient } from "@autifyhq/autify-sdk";
 import { Command, Flags } from "@oclif/core";
 import emoji from "node-emoji";
 import { getBuildDetailUrl } from "../../../autify/mobile/getBuildDetailUrl";
+import { getMobileClient } from "../../../autify/mobile/getMobileClient";
 import { uploadBuild } from "../../../autify/mobile/uploadBuild";
-import { get, getOrThrow } from "../../../config";
 
 export default class MobileBuildUpload extends Command {
   static enableJsonFlag = true;
@@ -37,9 +36,7 @@ export default class MobileBuildUpload extends Command {
     const buildPath = args["build-path"];
     const workspaceId = flags["workspace-id"];
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_MOBILE_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_MOBILE_BASE_PATH");
-    const client = new MobileClient(accessToken, { basePath, userAgent });
+    const client = getMobileClient(configDir, userAgent);
     const [buildId, os] = await uploadBuild(client, workspaceId, buildPath);
     const buildDetailUrl = getBuildDetailUrl(
       configDir,

--- a/src/commands/mobile/test/run.ts
+++ b/src/commands/mobile/test/run.ts
@@ -1,10 +1,9 @@
-import { MobileClient } from "@autifyhq/autify-sdk";
 import { Command, Flags } from "@oclif/core";
 import { CLIError } from "@oclif/errors";
 import emoji from "node-emoji";
+import { getMobileClient } from "../../../autify/mobile/getMobileClient";
 import { getMobileTestResultUrl } from "../../../autify/mobile/getTestResultUrl";
 import { parseTestPlanUrl } from "../../../autify/mobile/parseTestPlanUrl";
-import { get, getOrThrow } from "../../../config";
 import MobileBuildUpload from "../build/upload";
 import MobileTestWait from "./wait";
 
@@ -63,9 +62,7 @@ export default class MobileTestRun extends Command {
     let buildId = flags["build-id"];
     const buildPath = flags["build-path"];
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_MOBILE_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_MOBILE_BASE_PATH");
-    const client = new MobileClient(accessToken, { basePath, userAgent });
+    const client = getMobileClient(configDir, userAgent);
     const { workspaceId, testPlanId } = parseTestPlanUrl(args["test-plan-url"]);
     if (buildPath) {
       const uploadArgs = ["--workspace-id", workspaceId, buildPath];

--- a/src/commands/mobile/test/wait.ts
+++ b/src/commands/mobile/test/wait.ts
@@ -1,11 +1,10 @@
-import { MobileClient } from "@autifyhq/autify-sdk";
 import { Command, Flags } from "@oclif/core";
 import emoji from "node-emoji";
 import { getWaitIntervalSecond } from "../../../autify/getWaitIntervalSecond";
+import { getMobileClient } from "../../../autify/mobile/getMobileClient";
 import { getMobileTestResultUrl } from "../../../autify/mobile/getTestResultUrl";
 import { parseTestResultUrl } from "../../../autify/mobile/parseTestResultUrl";
 import { waitTestResult } from "../../../autify/mobile/waitTestResult";
-import { get, getOrThrow } from "../../../config";
 
 export default class MobileTestWait extends Command {
   static description = "Wait a test result until it finishes.";
@@ -40,10 +39,8 @@ export default class MobileTestWait extends Command {
   public async run(): Promise<void> {
     const { args, flags } = await this.parse(MobileTestWait);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_MOBILE_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_MOBILE_BASE_PATH");
     const waitIntervalSecond = getWaitIntervalSecond(configDir);
-    const client = new MobileClient(accessToken, { basePath, userAgent });
+    const client = getMobileClient(configDir, userAgent);
     const { workspaceId, resultId } = parseTestResultUrl(
       args["test-result-url"]
     );

--- a/src/commands/web/api/create-access-point.ts
+++ b/src/commands/web/api/create-access-point.ts
@@ -1,6 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import { WebClient as Client } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
+import { getWebClient } from "../../../autify/web/getWebClient";
 
 export default class WebApiCreateAccessPoint extends Command {
   static description =
@@ -23,9 +22,7 @@ export default class WebApiCreateAccessPoint extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(WebApiCreateAccessPoint);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
-    const client = new Client(accessToken, { basePath, userAgent });
+    const client = getWebClient(configDir, userAgent);
     const res = await client.createAccessPoint(
       flags["project-id"],
       JSON.parse(flags["create-access-point-request"])

--- a/src/commands/web/api/create-url-replacement.ts
+++ b/src/commands/web/api/create-url-replacement.ts
@@ -1,6 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import { WebClient as Client } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
+import { getWebClient } from "../../../autify/web/getWebClient";
 
 export default class WebApiCreateUrlReplacement extends Command {
   static description = "Create a new url replacement for the test plan";
@@ -22,9 +21,7 @@ export default class WebApiCreateUrlReplacement extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(WebApiCreateUrlReplacement);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
-    const client = new Client(accessToken, { basePath, userAgent });
+    const client = getWebClient(configDir, userAgent);
     const res = await client.createUrlReplacement(
       flags["test-plan-id"],
       JSON.parse(flags["create-url-replacement-request"])

--- a/src/commands/web/api/delete-access-point.ts
+++ b/src/commands/web/api/delete-access-point.ts
@@ -1,6 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import { WebClient as Client } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
+import { getWebClient } from "../../../autify/web/getWebClient";
 
 export default class WebApiDeleteAccessPoint extends Command {
   static description = "You can delete an access point by passing in its name.";
@@ -22,9 +21,7 @@ export default class WebApiDeleteAccessPoint extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(WebApiDeleteAccessPoint);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
-    const client = new Client(accessToken, { basePath, userAgent });
+    const client = getWebClient(configDir, userAgent);
     const res = await client.deleteAccessPoint(
       flags["project-id"],
       JSON.parse(flags["delete-access-point-request"])

--- a/src/commands/web/api/delete-url-replacement.ts
+++ b/src/commands/web/api/delete-url-replacement.ts
@@ -1,6 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import { WebClient as Client } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
+import { getWebClient } from "../../../autify/web/getWebClient";
 
 export default class WebApiDeleteUrlReplacement extends Command {
   static description = "Delete a url replacement for the test plan";
@@ -22,9 +21,7 @@ export default class WebApiDeleteUrlReplacement extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(WebApiDeleteUrlReplacement);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
-    const client = new Client(accessToken, { basePath, userAgent });
+    const client = getWebClient(configDir, userAgent);
     const res = await client.deleteUrlReplacement(
       flags["test-plan-id"],
       flags["url-replacement-id"]

--- a/src/commands/web/api/describe-result.ts
+++ b/src/commands/web/api/describe-result.ts
@@ -1,6 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import { WebClient as Client } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
+import { getWebClient } from "../../../autify/web/getWebClient";
 
 export default class WebApiDescribeResult extends Command {
   static description = "Get a result.";
@@ -23,9 +22,7 @@ export default class WebApiDescribeResult extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(WebApiDescribeResult);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
-    const client = new Client(accessToken, { basePath, userAgent });
+    const client = getWebClient(configDir, userAgent);
     const res = await client.describeResult(
       flags["project-id"],
       flags["result-id"]

--- a/src/commands/web/api/describe-scenario.ts
+++ b/src/commands/web/api/describe-scenario.ts
@@ -1,6 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import { WebClient as Client } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
+import { getWebClient } from "../../../autify/web/getWebClient";
 
 export default class WebApiDescribeScenario extends Command {
   static description = "Get a scenario.";
@@ -23,9 +22,7 @@ export default class WebApiDescribeScenario extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(WebApiDescribeScenario);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
-    const client = new Client(accessToken, { basePath, userAgent });
+    const client = getWebClient(configDir, userAgent);
     const res = await client.describeScenario(
       flags["project-id"],
       flags["scenario-id"]

--- a/src/commands/web/api/execute-scenarios.ts
+++ b/src/commands/web/api/execute-scenarios.ts
@@ -1,6 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import { WebClient as Client } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
+import { getWebClient } from "../../../autify/web/getWebClient";
 
 export default class WebApiExecuteScenarios extends Command {
   static description =
@@ -23,9 +22,7 @@ export default class WebApiExecuteScenarios extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(WebApiExecuteScenarios);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
-    const client = new Client(accessToken, { basePath, userAgent });
+    const client = getWebClient(configDir, userAgent);
     const res = await client.executeScenarios(
       flags["project-id"],
       JSON.parse(flags["execute-scenarios-request"])

--- a/src/commands/web/api/execute-schedule.ts
+++ b/src/commands/web/api/execute-schedule.ts
@@ -1,6 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import { WebClient as Client } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
+import { getWebClient } from "../../../autify/web/getWebClient";
 
 export default class WebApiExecuteSchedule extends Command {
   static description =
@@ -23,9 +22,7 @@ export default class WebApiExecuteSchedule extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(WebApiExecuteSchedule);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
-    const client = new Client(accessToken, { basePath, userAgent });
+    const client = getWebClient(configDir, userAgent);
     const res = await client.executeSchedule(
       flags["schedule-id"],
       flags["execute-schedule-request"]

--- a/src/commands/web/api/list-access-points.ts
+++ b/src/commands/web/api/list-access-points.ts
@@ -1,6 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import { WebClient as Client } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
+import { getWebClient } from "../../../autify/web/getWebClient";
 
 export default class WebApiListAccessPoints extends Command {
   static description = "List access points for the project.";
@@ -22,9 +21,7 @@ export default class WebApiListAccessPoints extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(WebApiListAccessPoints);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
-    const client = new Client(accessToken, { basePath, userAgent });
+    const client = getWebClient(configDir, userAgent);
     const res = await client.listAccessPoints(flags["project-id"], flags.page);
     console.log(JSON.stringify(res.data, null, 2));
   }

--- a/src/commands/web/api/list-capabilities.ts
+++ b/src/commands/web/api/list-capabilities.ts
@@ -1,6 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import { WebClient as Client } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
+import { getWebClient } from "../../../autify/web/getWebClient";
 
 export default class WebApiListCapabilities extends Command {
   static description = "List available Capabilities.";
@@ -27,9 +26,7 @@ export default class WebApiListCapabilities extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(WebApiListCapabilities);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
-    const client = new Client(accessToken, { basePath, userAgent });
+    const client = getWebClient(configDir, userAgent);
     const res = await client.listCapabilities(
       flags["project-id"],
       flags.os,

--- a/src/commands/web/api/list-results.ts
+++ b/src/commands/web/api/list-results.ts
@@ -1,6 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import { WebClient as Client } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
+import { getWebClient } from "../../../autify/web/getWebClient";
 
 export default class WebApiListResults extends Command {
   static description = "List results.";
@@ -31,9 +30,7 @@ export default class WebApiListResults extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(WebApiListResults);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
-    const client = new Client(accessToken, { basePath, userAgent });
+    const client = getWebClient(configDir, userAgent);
     const res = await client.listResults(
       flags["project-id"],
       flags.page,

--- a/src/commands/web/api/list-scenarios.ts
+++ b/src/commands/web/api/list-scenarios.ts
@@ -1,6 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import { WebClient as Client } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
+import { getWebClient } from "../../../autify/web/getWebClient";
 
 export default class WebApiListScenarios extends Command {
   static description = "List scenarios.";
@@ -22,9 +21,7 @@ export default class WebApiListScenarios extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(WebApiListScenarios);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
-    const client = new Client(accessToken, { basePath, userAgent });
+    const client = getWebClient(configDir, userAgent);
     const res = await client.listScenarios(flags["project-id"], flags.page);
     console.log(JSON.stringify(res.data, null, 2));
   }

--- a/src/commands/web/api/list-url-replacements.ts
+++ b/src/commands/web/api/list-url-replacements.ts
@@ -1,6 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import { WebClient as Client } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
+import { getWebClient } from "../../../autify/web/getWebClient";
 
 export default class WebApiListUrlReplacements extends Command {
   static description = "List url replacements for the test plan";
@@ -18,9 +17,7 @@ export default class WebApiListUrlReplacements extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(WebApiListUrlReplacements);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
-    const client = new Client(accessToken, { basePath, userAgent });
+    const client = getWebClient(configDir, userAgent);
     const res = await client.listUrlReplacements(flags["test-plan-id"]);
     console.log(JSON.stringify(res.data, null, 2));
   }

--- a/src/commands/web/api/update-url-replacement.ts
+++ b/src/commands/web/api/update-url-replacement.ts
@@ -1,6 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import { WebClient as Client } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
+import { getWebClient } from "../../../autify/web/getWebClient";
 
 export default class WebApiUpdateUrlReplacement extends Command {
   static description = "Update a url replacement for the test plan";
@@ -27,9 +26,7 @@ export default class WebApiUpdateUrlReplacement extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(WebApiUpdateUrlReplacement);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
-    const client = new Client(accessToken, { basePath, userAgent });
+    const client = getWebClient(configDir, userAgent);
     const res = await client.updateUrlReplacement(
       flags["test-plan-id"],
       flags["url-replacement-id"],

--- a/src/commands/web/test/run.ts
+++ b/src/commands/web/test/run.ts
@@ -1,13 +1,12 @@
 import { Command, Flags } from "@oclif/core";
 import emoji from "node-emoji";
-import { WebClient } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
 import { runTest } from "../../../autify/web/runTest";
 import { getWebTestResultUrl } from "../../../autify/web/getTestResultUrl";
 import WebTestWait from "./wait";
 import { CLIError } from "@oclif/errors";
 import { parseAutifyTestUrl } from "../../../autify/web/parseAutifyTestUrl";
 import { ClientManager } from "../../../autify/connect/client-manager/ClientManager";
+import { getWebClient } from "../../../autify/web/getWebClient";
 
 const parseUrlReplacements = (urlReplacements: string[]) => {
   return urlReplacements.map((s) => {
@@ -147,9 +146,7 @@ export default class WebTestRun extends Command {
         )}`
       );
     const { configDir, cacheDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
-    const client = new WebClient(accessToken, { basePath, userAgent });
+    const client = getWebClient(configDir, userAgent);
 
     const parsedTest = parseAutifyTestUrl(args["scenario-or-test-plan-url"]);
     const { workspaceId } = parsedTest;

--- a/src/commands/web/test/wait.ts
+++ b/src/commands/web/test/wait.ts
@@ -1,11 +1,10 @@
 import { Command, Flags } from "@oclif/core";
 import emoji from "node-emoji";
-import { WebClient } from "@autifyhq/autify-sdk";
-import { get, getOrThrow } from "../../../config";
 import { parseTestResultUrl } from "../../../autify/web/parseTestResultUrl";
 import { waitTestResult } from "../../../autify/web/waitTestResult";
 import { getWebTestResultUrl } from "../../../autify/web/getTestResultUrl";
 import { getWaitIntervalSecond } from "../../../autify/getWaitIntervalSecond";
+import { getWebClient } from "../../../autify/web/getWebClient";
 
 export default class WebTestWait extends Command {
   static description = "Wait a test result until it finishes.";
@@ -40,10 +39,8 @@ export default class WebTestWait extends Command {
   public async run(): Promise<void> {
     const { args, flags } = await this.parse(WebTestWait);
     const { configDir, userAgent } = this.config;
-    const accessToken = getOrThrow(configDir, "AUTIFY_WEB_ACCESS_TOKEN");
-    const basePath = get(configDir, "AUTIFY_WEB_BASE_PATH");
     const waitIntervalSecond = getWaitIntervalSecond(configDir);
-    const client = new WebClient(accessToken, { basePath, userAgent });
+    const client = getWebClient(configDir, userAgent);
     const { workspaceId, resultId } = parseTestResultUrl(
       args["test-result-url"]
     );

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ type Variable =
   | "AUTIFY_CONNECT_ACCESS_POINT_NAME"
   | "AUTIFY_CONNECT_ACCESS_POINT_KEY"
   | "AUTIFY_CONNECT_CLIENT_MODE"
+  | "AUTIFY_CLI_USER_AGENT_SUFFIX"
   | "AUTIFY_TEST_WAIT_INTERVAL_SECOND";
 
 const envFile = (dir: string) => path.resolve(dir, "config.env");


### PR DESCRIPTION
To measure CLI usage deeply, this commit adds support to add prefix to the user agent via `AUTIFY_CLI_USER_AGENT_SUFFIX` environment variable.

This commit also refactor web/mobile client instantiations by centralizing them.

Close #170 