### PR TITLE
Support Autify Connect with test plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,13 +726,12 @@ FLAGS
                                                      test execution.
   -v, --verbose                                      Verbose output
   -w, --wait                                         Wait until the test finishes.
-  --autify-connect=<value>                           [Only for test scenario] Name of the Autify Connect Access Point.
-  --autify-connect-client                            [Only for test scenario] Start Autify Connect Client
-  --autify-connect-client-debug-server-port=<value>  [Only for test scenario] Port for Autify Connect Client debug
-                                                     server. A random port will be used if not specified.
-  --autify-connect-client-file-logging               [Only for test scenario] Logging Autify Connect Client log to a
-                                                     file instead of console.
-  --autify-connect-client-verbose                    [Only for test scenario] Verbose output for Autify Connect Client.
+  --autify-connect=<value>                           Name of the Autify Connect Access Point.
+  --autify-connect-client                            Start Autify Connect Client
+  --autify-connect-client-debug-server-port=<value>  Port for Autify Connect Client debug server. A random port will be
+                                                     used if not specified.
+  --autify-connect-client-file-logging               Logging Autify Connect Client log to a file instead of console.
+  --autify-connect-client-verbose                    Verbose output for Autify Connect Client.
   --browser=<value>                                  [Only for test scenario] Browser to run the test
   --device=<value>                                   [Only for test scenario] Device to run the test
   --device-type=<value>                              [Only for test scenario] Device type to run the test

--- a/integration-test/__recordings__/web%20test%20run%20--autify-connect-client%20--wait%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Ftest_plans%2F169408/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/web%20test%20run%20--autify-connect-client%20--wait%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Ftest_plans%2F169408/polly-proxy_3343057686/recording.har
@@ -1,0 +1,521 @@
+{
+  "log": {
+    "_recordingName": "polly-proxy",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "ca1c840c1d5ab757390ab157656f4d13",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 58,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 341,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"name\":\"autify-cli-576f4b9e-2bb5-4c65-8820-586d92b60c81\"}"
+          },
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/autify_connect/access_points"
+        },
+        "response": {
+          "bodySize": 211,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 211,
+            "text": "{\"name\":\"autify-cli-576f4b9e-2bb5-4c65-8820-586d92b60c81\",\"key\":\"000000000000000000000000000000\",\"last_use\":null,\"creator\":\"riywo\",\"created_at\":\"2022-09-27T22:46:49.720Z\",\"updated_at\":\"2022-09-27T22:46:49.720Z\"}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:46:49.025Z",
+        "time": 757,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 757
+        }
+      },
+      {
+        "_id": "44c118897ef5fc83a597c7ad8721798a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 77,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 316,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"autify_connect\":{\"name\":\"autify-cli-576f4b9e-2bb5-4c65-8820-586d92b60c81\"}}"
+          },
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/schedules/169408"
+        },
+        "response": {
+          "bodySize": 79,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 79,
+            "text": "{\"data\":{\"id\":\"1222374\",\"type\":\"test_plan_result\",\"attributes\":{\"id\":1222374}}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:46:49.855Z",
+        "time": 603,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 603
+        }
+      },
+      {
+        "_id": "579a811f5b7cf3683e26919978b9b027",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222374"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1222374,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:46:51.479Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:46:50.376Z\",\"updated_at\":\"2022-09-27T22:46:51.511Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445936,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282539,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:46:51.479Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:46:51.202Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222374/capabilities/1445936/scenarios/4282539\",\"updated_at\":\"2022-09-27T22:46:51.631Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:46:51.486Z",
+        "time": 537,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 537
+        }
+      },
+      {
+        "_id": "579a811f5b7cf3683e26919978b9b027",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222374"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1222374,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:46:51.479Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:46:50.376Z\",\"updated_at\":\"2022-09-27T22:46:51.511Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445936,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282539,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:46:51.479Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:46:51.202Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222374/capabilities/1445936/scenarios/4282539\",\"updated_at\":\"2022-09-27T22:46:51.631Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:46:52.487Z",
+        "time": 483,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 483
+        }
+      },
+      {
+        "_id": "579a811f5b7cf3683e26919978b9b027",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222374"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1222374,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:46:51.479Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:46:50.376Z\",\"updated_at\":\"2022-09-27T22:46:51.511Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445936,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282539,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:46:51.479Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:46:51.202Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222374/capabilities/1445936/scenarios/4282539\",\"updated_at\":\"2022-09-27T22:46:51.631Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:46:53.488Z",
+        "time": 513,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 513
+        }
+      },
+      {
+        "_id": "579a811f5b7cf3683e26919978b9b027",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222374"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1222374,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:46:51.479Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:46:50.376Z\",\"updated_at\":\"2022-09-27T22:46:51.511Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445936,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282539,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:46:51.479Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:46:51.202Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222374/capabilities/1445936/scenarios/4282539\",\"updated_at\":\"2022-09-27T22:46:51.631Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:46:54.489Z",
+        "time": 498,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 498
+        }
+      },
+      {
+        "_id": "579a811f5b7cf3683e26919978b9b027",
+        "_order": 4,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222374"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1222374,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:46:51.479Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:46:50.376Z\",\"updated_at\":\"2022-09-27T22:46:51.511Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445936,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282539,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:46:51.479Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:46:51.202Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222374/capabilities/1445936/scenarios/4282539\",\"updated_at\":\"2022-09-27T22:46:51.631Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:46:55.489Z",
+        "time": 492,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 492
+        }
+      },
+      {
+        "_id": "579a811f5b7cf3683e26919978b9b027",
+        "_order": 5,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222374"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1222374,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:46:51.479Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:46:50.376Z\",\"updated_at\":\"2022-09-27T22:46:51.511Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445936,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282539,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:46:51.479Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:46:51.202Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222374/capabilities/1445936/scenarios/4282539\",\"updated_at\":\"2022-09-27T22:46:51.631Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:46:56.489Z",
+        "time": 501,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 501
+        }
+      },
+      {
+        "_id": "579a811f5b7cf3683e26919978b9b027",
+        "_order": 6,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222374"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1222374,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:46:51.479Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:46:50.376Z\",\"updated_at\":\"2022-09-27T22:46:51.511Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445936,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282539,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:46:51.479Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:46:51.202Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222374/capabilities/1445936/scenarios/4282539\",\"updated_at\":\"2022-09-27T22:46:51.631Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:46:57.490Z",
+        "time": 514,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 514
+        }
+      },
+      {
+        "_id": "579a811f5b7cf3683e26919978b9b027",
+        "_order": 7,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222374"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1222374,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:46:51.479Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:46:50.376Z\",\"updated_at\":\"2022-09-27T22:46:51.511Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445936,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282539,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:46:51.479Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:46:51.202Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222374/capabilities/1445936/scenarios/4282539\",\"updated_at\":\"2022-09-27T22:46:51.631Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:46:58.491Z",
+        "time": 522,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 522
+        }
+      },
+      {
+        "_id": "579a811f5b7cf3683e26919978b9b027",
+        "_order": 8,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222374"
+        },
+        "response": {
+          "bodySize": 974,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 974,
+            "text": "{\"id\":1222374,\"status\":\"passed\",\"duration\":5816,\"started_at\":\"2022-09-27T22:46:51.479Z\",\"finished_at\":\"2022-09-27T22:46:57.296Z\",\"created_at\":\"2022-09-27T22:46:50.376Z\",\"updated_at\":\"2022-09-27T22:46:59.867Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445936,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282539,\"test_case_id\":91437,\"status\":\"passed\",\"duration\":4535,\"started_at\":\"2022-09-27T22:46:52.761Z\",\"finished_at\":\"2022-09-27T22:46:57.296Z\",\"created_at\":\"2022-09-27T22:46:51.202Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222374/capabilities/1445936/scenarios/4282539\",\"updated_at\":\"2022-09-27T22:46:59.813Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:46:59.493Z",
+        "time": 453,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 453
+        }
+      },
+      {
+        "_id": "1ac72866dc2e3e0fac4332fdcabc60ed",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 58,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 343,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"name\":\"autify-cli-576f4b9e-2bb5-4c65-8820-586d92b60c81\"}"
+          },
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/autify_connect/access_points"
+        },
+        "response": {
+          "bodySize": 2,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2,
+            "text": "{}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:47:00.958Z",
+        "time": 535,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 535
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/integration-test/__recordings__/web%20test%20run%20--wait%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Ftest_plans%2F169408/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/web%20test%20run%20--wait%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Ftest_plans%2F169408/polly-proxy_3343057686/recording.har
@@ -1,0 +1,511 @@
+{
+  "log": {
+    "_recordingName": "polly-proxy",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "7f9d7d4e2c82f25cb63268cfc149f892",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 315,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/schedules/169408"
+        },
+        "response": {
+          "bodySize": 79,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 79,
+            "text": "{\"data\":{\"id\":\"1222373\",\"type\":\"test_plan_result\",\"attributes\":{\"id\":1222373}}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:45:35.679Z",
+        "time": 575,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 575
+        }
+      },
+      {
+        "_id": "744aad8b722219414ef5a42b62e1dbb8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222373"
+        },
+        "response": {
+          "bodySize": 888,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 888,
+            "text": "{\"id\":1222373,\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:36.181Z\",\"updated_at\":\"2022-09-27T22:45:37.532Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445935,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282538,\"test_case_id\":91437,\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:37.516Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222373/capabilities/1445935/scenarios/4282538\",\"updated_at\":\"2022-09-27T22:45:37.555Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:45:37.285Z",
+        "time": 478,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 478
+        }
+      },
+      {
+        "_id": "744aad8b722219414ef5a42b62e1dbb8",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222373"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1222373,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:45:37.868Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:36.181Z\",\"updated_at\":\"2022-09-27T22:45:37.943Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445935,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282538,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:45:37.868Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:37.516Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222373/capabilities/1445935/scenarios/4282538\",\"updated_at\":\"2022-09-27T22:45:38.046Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:45:38.284Z",
+        "time": 465,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 465
+        }
+      },
+      {
+        "_id": "744aad8b722219414ef5a42b62e1dbb8",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222373"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1222373,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:45:37.868Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:36.181Z\",\"updated_at\":\"2022-09-27T22:45:37.943Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445935,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282538,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:45:37.868Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:37.516Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222373/capabilities/1445935/scenarios/4282538\",\"updated_at\":\"2022-09-27T22:45:38.046Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:45:39.284Z",
+        "time": 519,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 519
+        }
+      },
+      {
+        "_id": "744aad8b722219414ef5a42b62e1dbb8",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222373"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1222373,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:45:37.868Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:36.181Z\",\"updated_at\":\"2022-09-27T22:45:37.943Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445935,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282538,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:45:37.868Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:37.516Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222373/capabilities/1445935/scenarios/4282538\",\"updated_at\":\"2022-09-27T22:45:38.046Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:45:40.286Z",
+        "time": 546,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 546
+        }
+      },
+      {
+        "_id": "744aad8b722219414ef5a42b62e1dbb8",
+        "_order": 4,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222373"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1222373,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:45:37.868Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:36.181Z\",\"updated_at\":\"2022-09-27T22:45:37.943Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445935,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282538,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:45:37.868Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:37.516Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222373/capabilities/1445935/scenarios/4282538\",\"updated_at\":\"2022-09-27T22:45:38.046Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:45:41.286Z",
+        "time": 512,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 512
+        }
+      },
+      {
+        "_id": "744aad8b722219414ef5a42b62e1dbb8",
+        "_order": 5,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222373"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1222373,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:45:37.868Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:36.181Z\",\"updated_at\":\"2022-09-27T22:45:37.943Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445935,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282538,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:45:37.868Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:37.516Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222373/capabilities/1445935/scenarios/4282538\",\"updated_at\":\"2022-09-27T22:45:38.046Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:45:42.286Z",
+        "time": 539,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 539
+        }
+      },
+      {
+        "_id": "744aad8b722219414ef5a42b62e1dbb8",
+        "_order": 6,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222373"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1222373,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:45:37.868Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:36.181Z\",\"updated_at\":\"2022-09-27T22:45:37.943Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445935,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282538,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:45:37.868Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:37.516Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222373/capabilities/1445935/scenarios/4282538\",\"updated_at\":\"2022-09-27T22:45:38.046Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:45:43.285Z",
+        "time": 483,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 483
+        }
+      },
+      {
+        "_id": "744aad8b722219414ef5a42b62e1dbb8",
+        "_order": 7,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222373"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1222373,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:45:37.868Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:36.181Z\",\"updated_at\":\"2022-09-27T22:45:37.943Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445935,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282538,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:45:37.868Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:37.516Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222373/capabilities/1445935/scenarios/4282538\",\"updated_at\":\"2022-09-27T22:45:38.046Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:45:44.287Z",
+        "time": 555,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 555
+        }
+      },
+      {
+        "_id": "744aad8b722219414ef5a42b62e1dbb8",
+        "_order": 8,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222373"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1222373,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:45:37.868Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:36.181Z\",\"updated_at\":\"2022-09-27T22:45:37.943Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445935,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282538,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:45:37.868Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:37.516Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222373/capabilities/1445935/scenarios/4282538\",\"updated_at\":\"2022-09-27T22:45:38.046Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:45:45.287Z",
+        "time": 512,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 512
+        }
+      },
+      {
+        "_id": "744aad8b722219414ef5a42b62e1dbb8",
+        "_order": 9,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222373"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1222373,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:45:37.868Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:36.181Z\",\"updated_at\":\"2022-09-27T22:45:37.943Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445935,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282538,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2022-09-27T22:45:37.868Z\",\"finished_at\":null,\"created_at\":\"2022-09-27T22:45:37.516Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222373/capabilities/1445935/scenarios/4282538\",\"updated_at\":\"2022-09-27T22:45:38.046Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:45:46.288Z",
+        "time": 515,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 515
+        }
+      },
+      {
+        "_id": "744aad8b722219414ef5a42b62e1dbb8",
+        "_order": 10,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1222373"
+        },
+        "response": {
+          "bodySize": 974,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 974,
+            "text": "{\"id\":1222373,\"status\":\"passed\",\"duration\":6525,\"started_at\":\"2022-09-27T22:45:37.868Z\",\"finished_at\":\"2022-09-27T22:45:44.394Z\",\"created_at\":\"2022-09-27T22:45:36.181Z\",\"updated_at\":\"2022-09-27T22:45:47.174Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":1445935,\"capability\":{\"id\":346735,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"104.0\",\"device\":\"\",\"created_at\":\"2022-08-22T03:57:59.193Z\",\"updated_at\":\"2022-08-22T03:57:59.193Z\"},\"test_case_results\":[{\"id\":4282538,\"test_case_id\":91437,\"status\":\"passed\",\"duration\":5283,\"started_at\":\"2022-09-27T22:45:39.111Z\",\"finished_at\":\"2022-09-27T22:45:44.394Z\",\"created_at\":\"2022-09-27T22:45:37.516Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1222373/capabilities/1445935/scenarios/4282538\",\"updated_at\":\"2022-09-27T22:45:47.090Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:45:47.288Z",
+        "time": 475,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 475
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/integration-test/__recordings__/web%20test%20run%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Ftest_plans%2F169408/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/web%20test%20run%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Ftest_plans%2F169408/polly-proxy_3343057686/recording.har
@@ -1,0 +1,60 @@
+{
+  "log": {
+    "_recordingName": "polly-proxy",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "7f9d7d4e2c82f25cb63268cfc149f892",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 315,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/schedules/169408"
+        },
+        "response": {
+          "bodySize": 79,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 79,
+            "text": "{\"data\":{\"id\":\"1222367\",\"type\":\"test_plan_result\",\"attributes\":{\"id\":1222367}}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-27T22:44:39.674Z",
+        "time": 584,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 584
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/integration-test/__snapshots__/golden/webTestRunTestPlan.test.js.snap
+++ b/integration-test/__snapshots__/golden/webTestRunTestPlan.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`autify web test run https://app.autify.com/projects/0000/test_plans/0000 1`] = `
+Object {
+  "stderr": "",
+  "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
+[HPM] Proxy created: /  -> https://mobile-app.autify.com
+✅ Successfully started: https://app.autify.com/projects/743/results/1222367 (Capability is configured by test plan)
+To wait for the test result, run the command below:
+💻 $ autify web test wait https://app.autify.com/projects/743/results/1222367
+[HPM] server close signal received: closing proxy server
+",
+}
+`;

--- a/integration-test/__snapshots__/golden/webTestRunTestPlanAutifyConnectClient.test.js.snap
+++ b/integration-test/__snapshots__/golden/webTestRunTestPlanAutifyConnectClient.test.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`autify web test run https://app.autify.com/projects/0000/test_plans/0000 --wait --autify-connect-client 1`] = `
+Object {
+  "stderr": "",
+  "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
+[HPM] Proxy created: /  -> https://mobile-app.autify.com
+[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Ephemeral Access Point was created: autify-cli-576f4b9e-2bb5-4c65-8820-586d92b60c81
+Starting Autify Connect Client...
+[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Starting Autify Connect Client (accessPoint: autify-cli-576f4b9e-2bb5-4c65-8820-586d92b60c81, debugServerPort: <random>, path: /path/to/autifyconnect-fake, version: Autify Connect version v0.6.3, build 7da4a94)
+Waiting until Autify Connect Client is ready...
+[Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	start serving a debug server on http://localhost:<random>
+[Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	Starting to establish a secure connection with the Autify connect server. Your session ID is \\"fake\\".
+[Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	Successfully connected!
+Autify Connect Client is ready!
+✅ Successfully started: https://app.autify.com/projects/743/results/1222374 (Capability is configured by test plan)
+🕐 Waiting for the test result: https://app.autify.com/projects/743/results/1222374
+[HH:MM:SS] Waiting... (timeout: 300 s) [started]
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
+[HH:MM:SS] → TestPlan: 👍 Passed , TestCases: 👍 Passed 
+[HH:MM:SS] Waiting... (timeout: 300 s) [completed]
+✅ Test passed!: https://app.autify.com/projects/743/results/1222374
+Waiting until Autify Connect Client exits...
+[Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	Interrupt received.
+[Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	Shutdown completed.
+[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Ephemeral Access Point was deleted: autify-cli-576f4b9e-2bb5-4c65-8820-586d92b60c81
+[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Autify Connect Client exited (code: 0, signal: null)
+Autify Connect Client exited.
+[HPM] server close signal received: closing proxy server
+",
+}
+`;

--- a/integration-test/__snapshots__/golden/webTestRunTestPlanWait.test.js.snap
+++ b/integration-test/__snapshots__/golden/webTestRunTestPlanWait.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`autify web test run https://app.autify.com/projects/0000/test_plans/0000 --wait 1`] = `
+Object {
+  "stderr": "",
+  "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
+[HPM] Proxy created: /  -> https://mobile-app.autify.com
+✅ Successfully started: https://app.autify.com/projects/743/results/1222373 (Capability is configured by test plan)
+🕐 Waiting for the test result: https://app.autify.com/projects/743/results/1222373
+[HH:MM:SS] Waiting... (timeout: 300 s) [started]
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
+[HH:MM:SS] → TestPlan: 👍 Passed , TestCases: 👍 Passed 
+[HH:MM:SS] Waiting... (timeout: 300 s) [completed]
+✅ Test passed!: https://app.autify.com/projects/743/results/1222373
+[HPM] server close signal received: closing proxy server
+",
+}
+`;

--- a/integration-test/src/commands.ts
+++ b/integration-test/src/commands.ts
@@ -3,6 +3,7 @@ export const androidBuildPath = "android.apk";
 
 const webTestScenarioUrl =
   "https://app.autify.com/projects/743/scenarios/91437";
+const webTestPlanUrl = "https://app.autify.com/projects/743/test_plans/169408";
 const mobileAndroidTestPlanUrl =
   "https://mobile-app.autify.com/projects/4yyFEL/test_plans/Wptd97";
 const mobileIosTestPlanUrl =
@@ -44,6 +45,12 @@ const replaceWebTestScenarioUrl = (arg: string) => {
   return regExp.test(arg) ? webTestScenarioUrl : arg;
 };
 
+const replaceWebTestPlanUrl = (arg: string) => {
+  const regExp =
+    /^https:\/\/app.autify.com\/projects\/\d+\/test_plans\/\d+\/?$/;
+  return regExp.test(arg) ? webTestPlanUrl : arg;
+};
+
 const replaceMobileTetsPlanUrl = (arg: string, os: "android" | "ios") => {
   const regExp =
     /^https:\/\/mobile-app.autify.com\/projects\/[^/]+\/test_plans\/[^/]+\/?$/;
@@ -78,7 +85,9 @@ const isIos = (args: string[]) => args.some((a) => a.endsWith(".app"));
 
 const replaceConstants = (args: string[]) => {
   if (args[0] === "web") {
-    return args.map((a) => replaceWebTestScenarioUrl(a));
+    return args
+      .map((a) => replaceWebTestScenarioUrl(a))
+      .map((a) => replaceWebTestPlanUrl(a));
   }
 
   if (args[0] === "mobile") {

--- a/integration-test/src/test/golden/webTestRunTestPlan.test.ts
+++ b/integration-test/src/test/golden/webTestRunTestPlan.test.ts
@@ -1,0 +1,6 @@
+/* eslint-disable unicorn/filename-case */
+import { testAutifyCliSnapshot } from "../helpers/testAutifyCliSnapshot";
+
+testAutifyCliSnapshot(
+  "web test run https://app.autify.com/projects/0000/test_plans/0000"
+);

--- a/integration-test/src/test/golden/webTestRunTestPlanAutifyConnectClient.test.ts
+++ b/integration-test/src/test/golden/webTestRunTestPlanAutifyConnectClient.test.ts
@@ -1,0 +1,6 @@
+/* eslint-disable unicorn/filename-case */
+import { testAutifyCliSnapshot } from "../helpers/testAutifyCliSnapshot";
+
+testAutifyCliSnapshot(
+  "web test run https://app.autify.com/projects/0000/test_plans/0000 --wait --autify-connect-client"
+);

--- a/integration-test/src/test/golden/webTestRunTestPlanWait.test.ts
+++ b/integration-test/src/test/golden/webTestRunTestPlanWait.test.ts
@@ -1,0 +1,6 @@
+/* eslint-disable unicorn/filename-case */
+import { testAutifyCliSnapshot } from "../helpers/testAutifyCliSnapshot";
+
+testAutifyCliSnapshot(
+  "web test run https://app.autify.com/projects/0000/test_plans/0000 --wait"
+);

--- a/src/autify/web/runTest.ts
+++ b/src/autify/web/runTest.ts
@@ -105,17 +105,20 @@ export const runTest = async (
       );
     if (name)
       throw new CLIError(`Running TestPlan doesn't support --name: ${name}`);
-    if (autifyConnectAccessPoint)
-      throw new CLIError(
-        "Running TestPlan doesn't support Autify Connect Access Point"
-      );
     const urlReplacementIds = [];
     for await (const urlReplacement of urlReplacements ?? []) {
       const res = await client.createUrlReplacement(testPlanId, urlReplacement);
       urlReplacementIds.push(res.data.id);
     }
 
-    const res = await client.executeSchedule(testPlanId);
+    const res = await client.executeSchedule(testPlanId, {
+      ...(autifyConnectAccessPoint && {
+        // eslint-disable-next-line camelcase
+        autify_connect: {
+          name: autifyConnectAccessPoint,
+        },
+      }),
+    });
     for await (const urlReplacementId of urlReplacementIds) {
       await client.deleteUrlReplacement(testPlanId, urlReplacementId);
     }

--- a/src/commands/web/test/run.ts
+++ b/src/commands/web/test/run.ts
@@ -54,28 +54,26 @@ export default class WebTestRun extends Command {
       multiple: true,
     }),
     "autify-connect": Flags.string({
-      description:
-        "[Only for test scenario] Name of the Autify Connect Access Point.",
+      description: "Name of the Autify Connect Access Point.",
       exclusive: ["autify-connect-client"],
     }),
     "autify-connect-client": Flags.boolean({
-      description: "[Only for test scenario] Start Autify Connect Client",
+      description: "Start Autify Connect Client",
       exclusive: ["autify-connect"],
       dependsOn: ["wait"],
     }),
     "autify-connect-client-verbose": Flags.boolean({
-      description:
-        "[Only for test scenario] Verbose output for Autify Connect Client.",
+      description: "Verbose output for Autify Connect Client.",
       dependsOn: ["autify-connect-client"],
     }),
     "autify-connect-client-file-logging": Flags.boolean({
       description:
-        "[Only for test scenario] Logging Autify Connect Client log to a file instead of console.",
+        "Logging Autify Connect Client log to a file instead of console.",
       dependsOn: ["autify-connect-client"],
     }),
     "autify-connect-client-debug-server-port": Flags.integer({
       description:
-        "[Only for test scenario] Port for Autify Connect Client debug server. A random port will be used if not specified.",
+        "Port for Autify Connect Client debug server. A random port will be used if not specified.",
       dependsOn: ["autify-connect-client"],
     }),
     os: Flags.string({


### PR DESCRIPTION
Since `executeSchedule` API is updated, we can now set Autify Connect Access Point when calling this API.

This commit add `autify-connect` and `autify-connect-client` support for test plan execution of `web test run`.