### PR TITLE
Update autify-sdk-js to use Axios v1

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -14,9 +14,4 @@ require('ts-node').register({project})
 oclif.settings.debug = true;
 
 // Start the CLI
-oclif.run().then(oclif.flush).catch(error => {
-  const oclifHandler = oclif.Errors.handle
-  // Workaround until this PR is released https://github.com/axios/axios/pull/4624
-  if (error.response?.data) console.error(JSON.stringify(error.response?.data, null, 2))
-  return oclifHandler(error)
-})
+oclif.run().then(oclif.flush).catch(oclif.Errors.handle)

--- a/bin/run
+++ b/bin/run
@@ -2,9 +2,4 @@
 
 const oclif = require('@oclif/core')
 
-oclif.run().then(require('@oclif/core/flush')).catch(error => {
-  const oclifHandler = require('@oclif/core/handle')
-  // Workaround until this PR is released https://github.com/axios/axios/pull/4624
-  if (error.response?.data) console.error(JSON.stringify(error.response?.data, null, 2))
-  return oclifHandler(error)
-})
+oclif.run().then(require('@oclif/core/flush')).catch(require('@oclif/core/handle'))

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "integration-test"
       ],
       "dependencies": {
-        "@autifyhq/autify-sdk": "^0.6.0",
+        "@autifyhq/autify-sdk": "^0.7.0-axios-v1.0",
         "@oclif/core": "^1",
         "@oclif/errors": "^1.3.6",
         "@oclif/plugin-help": "^5",
@@ -131,11 +131,11 @@
       "link": true
     },
     "node_modules/@autifyhq/autify-sdk": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@autifyhq/autify-sdk/-/autify-sdk-0.6.0.tgz",
-      "integrity": "sha512-ClVBOg4PP3TqBdw478RtRiwR/wPVUTuit95yP1fdxSVpIZaF5isplQlHt8JPSher9yiNJo+2AFPhmI9ces/uxQ==",
+      "version": "0.7.0-axios-v1.0",
+      "resolved": "https://registry.npmjs.org/@autifyhq/autify-sdk/-/autify-sdk-0.7.0-axios-v1.0.tgz",
+      "integrity": "sha512-AvrSy19JlXONQHXpjLY2leCNIC/tyS/5I+pHTMQgBHFnbC7qKwGT13kGp4oB46I+Npc6Jso5XEq7pdRTr3lj/w==",
       "dependencies": {
-        "axios": "^0.27.2",
+        "axios": "^1.1.2",
         "axios-logger": "^2.6.1",
         "debug": "^4.3.4",
         "form-data": "^4.0.0",
@@ -2975,12 +2975,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
+      "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axios-logger": {
@@ -11081,6 +11082,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -14325,11 +14331,11 @@
       }
     },
     "@autifyhq/autify-sdk": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@autifyhq/autify-sdk/-/autify-sdk-0.6.0.tgz",
-      "integrity": "sha512-ClVBOg4PP3TqBdw478RtRiwR/wPVUTuit95yP1fdxSVpIZaF5isplQlHt8JPSher9yiNJo+2AFPhmI9ces/uxQ==",
+      "version": "0.7.0-axios-v1.0",
+      "resolved": "https://registry.npmjs.org/@autifyhq/autify-sdk/-/autify-sdk-0.7.0-axios-v1.0.tgz",
+      "integrity": "sha512-AvrSy19JlXONQHXpjLY2leCNIC/tyS/5I+pHTMQgBHFnbC7qKwGT13kGp4oB46I+Npc6Jso5XEq7pdRTr3lj/w==",
       "requires": {
-        "axios": "^0.27.2",
+        "axios": "^1.1.2",
         "axios-logger": "^2.6.1",
         "debug": "^4.3.4",
         "form-data": "^4.0.0",
@@ -16647,12 +16653,13 @@
       }
     },
     "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
+      "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
       "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "axios-logger": {
@@ -22667,6 +22674,11 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "pump": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "/oclif.manifest.json"
   ],
   "dependencies": {
-    "@autifyhq/autify-sdk": "^0.6.0",
+    "@autifyhq/autify-sdk": "^0.7.0-axios-v1.0",
     "@oclif/core": "^1",
     "@oclif/errors": "^1.3.6",
     "@oclif/plugin-help": "^5",


### PR DESCRIPTION
The commit for checking it in beta channel. Before bumping `autify-cli` version, we need to release newer `autify-sdk-js` and switch to the version in `autify-cli`.