### PR TITLE
Fix actions/setup-node version to major only

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3.2.0
+    - uses: actions/setup-node@v3
       with:
         cache: npm
         registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
We shouldn't stick to a specific patch version.
