### PR TITLE
Migrate to `GITHUB_OUTPUT` from `set-output`

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -462,7 +462,8 @@ const validateCommand = (args: string[]) => {
 };
 
 const setOutput = (name: string, value: string) => {
-  console.log(`::set-output name=${name}::${value}`);
+  if (!process.env.GITHUB_OUTPUT) throw new Error("GITHUB_OUTPUT is empty");
+  writeFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}`, { flag: "a" });
 };
 
 const getInstallerUrlCommand = () => {


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
