### PR TITLE
Combine non major update only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,8 @@
   "packageRules": [
     {
       "matchDatasources": ["npm"],
-      "groupName": "all npm update"
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "all non major npm update"
     }
   ]
 }


### PR DESCRIPTION
I setup renovate bot via this PR https://github.com/autifyhq/autify-cli/pull/324
As a result we got single PR for updating but it contains both major and minor https://github.com/autifyhq/autify-cli/pull/325

I'd like to exclude major update