### PR TITLE
chore: exclude types/express 4.17.16

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,10 @@
       "matchDatasources": ["npm"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non major npm update"
+    },
+    {
+      "matchPackageNames": ["@types/express"],
+      "allowedVersions": ">=4.17.17"
     }
   ],
   "rangeStrategy": "bump",


### PR DESCRIPTION
4.17.16 made the CI failed and we need to wait for merging a patch. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64042