### PR TITLE
upgrade oclif/core to v2

### DIFF
--- a/integration-test/__recordings__/mobile%20build%20upload%20--json%20--workspace-id%3D4yyFEL%20android.apk/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/mobile%20build%20upload%20--json%20--workspace-id%3D4yyFEL%20android.apk/polly-proxy_3343057686/recording.har
@@ -15,11 +15,11 @@
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 403,
+          "headersSize": 404,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
-            "mimeType": "multipart/form-data; boundary=--------------------------830049273275804945839771",
+            "mimeType": "multipart/form-data; boundary=--------------------------134300787199565831469974",
             "params": []
           },
           "queryString": [],
@@ -30,7 +30,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 15,
-            "text": "{\"id\":\"90u6MG\"}"
+            "text": "{\"id\":\"zWu3yj\"}"
           },
           "cookies": [],
           "headers": [],
@@ -40,8 +40,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2023-03-09T09:31:10.206Z",
-        "time": 38530,
+        "startedDateTime": "2023-03-10T08:17:01.937Z",
+        "time": 22384,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -49,7 +49,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 38530
+          "wait": 22384
         }
       }
     ],

--- a/integration-test/__recordings__/mobile%20build%20upload%20--workspace-id%3D4yyFEL%20android.apk/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/mobile%20build%20upload%20--workspace-id%3D4yyFEL%20android.apk/polly-proxy_3343057686/recording.har
@@ -15,11 +15,11 @@
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 403,
+          "headersSize": 404,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
-            "mimeType": "multipart/form-data; boundary=--------------------------666632386737578010639756",
+            "mimeType": "multipart/form-data; boundary=--------------------------856936906741952013535564",
             "params": []
           },
           "queryString": [],
@@ -30,7 +30,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 15,
-            "text": "{\"id\":\"Eoue6q\"}"
+            "text": "{\"id\":\"oouMyw\"}"
           },
           "cookies": [],
           "headers": [],
@@ -40,8 +40,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2023-03-09T09:31:10.317Z",
-        "time": 38804,
+        "startedDateTime": "2023-03-10T08:17:02.078Z",
+        "time": 40729,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -49,7 +49,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 38804
+          "wait": 40729
         }
       }
     ],

--- a/integration-test/__recordings__/mobile%20build%20upload%20--workspace-id%3D4yyFEL%20ios.app/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/mobile%20build%20upload%20--workspace-id%3D4yyFEL%20ios.app/polly-proxy_3343057686/recording.har
@@ -15,11 +15,11 @@
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 403,
+          "headersSize": 404,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
-            "mimeType": "multipart/form-data; boundary=--------------------------711395095949545413117756",
+            "mimeType": "multipart/form-data; boundary=--------------------------364080330228899759470161",
             "params": []
           },
           "queryString": [],
@@ -30,7 +30,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 15,
-            "text": "{\"id\":\"Deu61W\"}"
+            "text": "{\"id\":\"7Vumnl\"}"
           },
           "cookies": [],
           "headers": [],
@@ -40,8 +40,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2023-03-09T09:31:11.233Z",
-        "time": 41842,
+        "startedDateTime": "2023-03-10T08:17:03.127Z",
+        "time": 42240,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -49,7 +49,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 41842
+          "wait": 42240
         }
       }
     ],

--- a/integration-test/__recordings__/mobile%20test%20run%20--build-id%3Dd1ulrD%20--wait%20https%3A%2F%2Fmobile-app.autify.com%2Fprojects%2F4yyFEL%2Ftest_plans%2FWptd97/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/mobile%20test%20run%20--build-id%3Dd1ulrD%20--wait%20https%3A%2F%2Fmobile-app.autify.com%2Fprojects%2F4yyFEL%2Ftest_plans%2FWptd97/polly-proxy_3343057686/recording.har
@@ -15,7 +15,7 @@
           "bodySize": 21,
           "cookies": [],
           "headers": [],
-          "headersSize": 344,
+          "headersSize": 345,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -31,7 +31,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 377,
-            "text": "{\"id\":\"X1t1WW\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T09:35:38.921Z\",\"updated_at\":\"2023-03-09T09:31:10.223Z\",\"build\":{\"id\":\"d1ulrD\",\"name\":\"Sunflower\",\"version\":\"0.1.6 1\",\"created_at\":\"2022-09-15T09:34:57.606Z\",\"updated_at\":\"2022-09-15T09:34:57.894Z\"},\"execute_environments\":[{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}]}}"
+            "text": "{\"id\":\"Mlt7VB\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T09:35:38.921Z\",\"updated_at\":\"2023-03-10T08:17:01.953Z\",\"build\":{\"id\":\"d1ulrD\",\"name\":\"Sunflower\",\"version\":\"0.1.6 1\",\"created_at\":\"2022-09-15T09:34:57.606Z\",\"updated_at\":\"2022-09-15T09:34:57.894Z\"},\"execute_environments\":[{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}]}}"
           },
           "cookies": [],
           "headers": [],
@@ -41,8 +41,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2023-03-09T09:31:09.659Z",
-        "time": 703,
+        "startedDateTime": "2023-03-10T08:17:01.684Z",
+        "time": 616,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -50,29 +50,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 703
+          "wait": 616
         }
       },
       {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
         "_order": 0,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
         },
         "response": {
-          "bodySize": 574,
+          "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -82,8 +82,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:11.406Z",
-        "time": 901,
+        "startedDateTime": "2023-03-10T08:17:03.334Z",
+        "time": 1044,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -91,29 +91,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 901
+          "wait": 1044
         }
       },
       {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
         "_order": 1,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
         },
         "response": {
-          "bodySize": 574,
+          "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -123,8 +123,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:12.405Z",
-        "time": 897,
+        "startedDateTime": "2023-03-10T08:17:04.391Z",
+        "time": 811,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -132,29 +132,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 897
+          "wait": 811
         }
       },
       {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
         "_order": 2,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
         },
         "response": {
-          "bodySize": 574,
+          "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -164,8 +164,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:13.406Z",
-        "time": 737,
+        "startedDateTime": "2023-03-10T08:17:05.336Z",
+        "time": 903,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -173,29 +173,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 737
+          "wait": 903
         }
       },
       {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
         "_order": 3,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
         },
         "response": {
-          "bodySize": 574,
+          "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -205,8 +205,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:14.408Z",
-        "time": 780,
+        "startedDateTime": "2023-03-10T08:17:06.334Z",
+        "time": 844,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -214,29 +214,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 780
+          "wait": 844
         }
       },
       {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
         "_order": 4,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
         },
         "response": {
-          "bodySize": 574,
+          "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -246,8 +246,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:15.408Z",
-        "time": 860,
+        "startedDateTime": "2023-03-10T08:17:07.337Z",
+        "time": 812,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -255,29 +255,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 860
+          "wait": 812
         }
       },
       {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
         "_order": 5,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
         },
         "response": {
-          "bodySize": 574,
+          "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -287,8 +287,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:16.409Z",
-        "time": 846,
+        "startedDateTime": "2023-03-10T08:17:08.339Z",
+        "time": 863,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -296,29 +296,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 846
+          "wait": 863
         }
       },
       {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
         "_order": 6,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
         },
         "response": {
-          "bodySize": 574,
+          "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -328,8 +328,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:17.410Z",
-        "time": 711,
+        "startedDateTime": "2023-03-10T08:17:09.339Z",
+        "time": 804,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -337,29 +337,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 711
+          "wait": 804
         }
       },
       {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
         "_order": 7,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
         },
         "response": {
-          "bodySize": 574,
+          "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -369,8 +369,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:18.412Z",
-        "time": 1057,
+        "startedDateTime": "2023-03-10T08:17:10.340Z",
+        "time": 809,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -378,29 +378,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1057
+          "wait": 809
         }
       },
       {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
         "_order": 8,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
         },
         "response": {
-          "bodySize": 574,
+          "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -410,8 +410,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:19.478Z",
-        "time": 958,
+        "startedDateTime": "2023-03-10T08:17:11.341Z",
+        "time": 837,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -419,29 +419,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 958
+          "wait": 837
         }
       },
       {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
         "_order": 9,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
         },
         "response": {
-          "bodySize": 574,
+          "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -451,8 +451,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:20.445Z",
-        "time": 834,
+        "startedDateTime": "2023-03-10T08:17:12.344Z",
+        "time": 659,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -460,29 +460,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 834
+          "wait": 659
         }
       },
       {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
         "_order": 10,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
         },
         "response": {
-          "bodySize": 574,
+          "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -492,7 +492,212 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:21.415Z",
+        "startedDateTime": "2023-03-10T08:17:13.344Z",
+        "time": 608,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 608
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 11,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:14.346Z",
+        "time": 898,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 898
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 12,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:15.346Z",
+        "time": 819,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 819
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 13,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:16.346Z",
+        "time": 847,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 847
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 14,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:17.345Z",
+        "time": 859,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 859
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 15,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:18.347Z",
         "time": 869,
         "timings": {
           "blocked": -1,
@@ -505,230 +710,25 @@
         }
       },
       {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
-        "_order": 11,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:22.415Z",
-        "time": 686,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 686
-        }
-      },
-      {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
-        "_order": 12,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:23.415Z",
-        "time": 643,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 643
-        }
-      },
-      {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
-        "_order": 13,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:24.417Z",
-        "time": 766,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 766
-        }
-      },
-      {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
-        "_order": 14,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:25.418Z",
-        "time": 892,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 892
-        }
-      },
-      {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
-        "_order": 15,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:26.418Z",
-        "time": 839,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 839
-        }
-      },
-      {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
         "_order": 16,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
         },
         "response": {
-          "bodySize": 574,
+          "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"passed\",\"duration\":15588,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -738,8 +738,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:27.418Z",
-        "time": 1045,
+        "startedDateTime": "2023-03-10T08:17:19.348Z",
+        "time": 902,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -747,29 +747,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1045
+          "wait": 902
         }
       },
       {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
         "_order": 17,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
         },
         "response": {
-          "bodySize": 574,
+          "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"passed\",\"duration\":15588,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -779,8 +779,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:28.471Z",
-        "time": 740,
+        "startedDateTime": "2023-03-10T08:17:20.350Z",
+        "time": 848,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -788,29 +788,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 740
+          "wait": 848
         }
       },
       {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
         "_order": 18,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
         },
         "response": {
-          "bodySize": 574,
+          "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"passed\",\"duration\":15588,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -820,8 +820,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:29.422Z",
-        "time": 842,
+        "startedDateTime": "2023-03-10T08:17:21.349Z",
+        "time": 780,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -829,29 +829,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 842
+          "wait": 780
         }
       },
       {
-        "_id": "b979feb2adef53a20ee083128f6b054c",
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
         "_order": 19,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/X1t1WW"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
         },
         "response": {
-          "bodySize": 601,
+          "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 601,
-            "text": "{\"id\":\"X1t1WW\",\"status\":\"passed\",\"duration\":15630,\"started_at\":\"2023-03-09T18:31:10.955+09:00\",\"finished_at\":\"2023-03-09T18:31:26.762+09:00\",\"created_at\":\"2023-03-09T18:31:10.255+09:00\",\"updated_at\":\"2023-03-09T18:31:30.584+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:10.249+09:00\"},\"test_case_results\":[{\"id\":\"d3I3grw\",\"status\":\"passed\",\"duration\":15588,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -861,8 +861,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:30.420Z",
-        "time": 803,
+        "startedDateTime": "2023-03-10T08:17:22.351Z",
+        "time": 804,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -870,7 +870,1155 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 803
+          "wait": 804
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 20,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:23.352Z",
+        "time": 701,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 701
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 21,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:24.350Z",
+        "time": 741,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 741
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 22,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:25.354Z",
+        "time": 743,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 743
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 23,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:26.356Z",
+        "time": 806,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 806
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 24,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:27.357Z",
+        "time": 832,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 832
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 25,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:28.357Z",
+        "time": 862,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 862
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 26,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:29.358Z",
+        "time": 831,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 831
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 27,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:30.360Z",
+        "time": 821,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 821
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 28,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:02.372+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:31.360Z",
+        "time": 1309,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1309
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 29,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:32.687+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:32.690+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:32.676Z",
+        "time": 734,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 734
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 30,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:32.687+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:32.690+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:33.419Z",
+        "time": 819,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 819
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 31,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:32.687+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:32.690+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:34.368Z",
+        "time": 847,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 847
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 32,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:32.687+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:32.690+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:35.369Z",
+        "time": 838,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 838
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 33,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:32.687+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:32.690+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:01.953+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:36.370Z",
+        "time": 690,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 690
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 34,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:32.687+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:32.690+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:37.778+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:37.370Z",
+        "time": 832,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 832
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 35,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:32.687+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:32.690+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:37.778+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:38.372Z",
+        "time": 774,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 774
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 36,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:32.687+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:32.690+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:39.373Z",
+        "time": 814,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 814
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 37,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:32.687+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:32.690+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:40.373Z",
+        "time": 694,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 694
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 38,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:32.687+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:32.690+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:41.376Z",
+        "time": 607,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 607
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 39,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:32.687+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:32.690+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:42.376Z",
+        "time": 577,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 577
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 40,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:32.687+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:32.690+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:43.379Z",
+        "time": 586,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 586
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 41,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:32.687+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:32.690+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:44.381Z",
+        "time": 605,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 605
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 42,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:32.687+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:32.690+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:45.381Z",
+        "time": 553,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 553
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 43,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:32.687+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:32.690+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:46.385Z",
+        "time": 572,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 572
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 44,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:32.687+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:32.690+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:47.386Z",
+        "time": 586,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 586
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 45,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:32.687+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:32.690+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:48.390Z",
+        "time": 605,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 605
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 46,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:32.687+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:32.690+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"passed\",\"duration\":15031,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:49.392Z",
+        "time": 547,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 547
+        }
+      },
+      {
+        "_id": "35b5e46dc728bf5400f62f84919703d7",
+        "_order": 47,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/Mlt7VB"
+        },
+        "response": {
+          "bodySize": 601,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 601,
+            "text": "{\"id\":\"Mlt7VB\",\"status\":\"passed\",\"duration\":15074,\"started_at\":\"2023-03-10T17:17:32.687+09:00\",\"finished_at\":\"2023-03-10T17:17:47.931+09:00\",\"created_at\":\"2023-03-10T17:17:02.218+09:00\",\"updated_at\":\"2023-03-10T17:17:50.086+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"rbIBDwg\",\"status\":\"passed\",\"duration\":15031,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"d1ulrD\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:50.392Z",
+        "time": 608,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 608
         }
       }
     ],

--- a/integration-test/__recordings__/mobile%20test%20run%20--build-id%3Dd1ulrD%20https%3A%2F%2Fmobile-app.autify.com%2Fprojects%2F4yyFEL%2Ftest_plans%2FWptd97/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/mobile%20test%20run%20--build-id%3Dd1ulrD%20https%3A%2F%2Fmobile-app.autify.com%2Fprojects%2F4yyFEL%2Ftest_plans%2FWptd97/polly-proxy_3343057686/recording.har
@@ -15,7 +15,7 @@
           "bodySize": 21,
           "cookies": [],
           "headers": [],
-          "headersSize": 344,
+          "headersSize": 345,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -31,7 +31,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 377,
-            "text": "{\"id\":\"gMt0Dy\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T09:35:38.921Z\",\"updated_at\":\"2023-03-09T09:31:10.249Z\",\"build\":{\"id\":\"d1ulrD\",\"name\":\"Sunflower\",\"version\":\"0.1.6 1\",\"created_at\":\"2022-09-15T09:34:57.606Z\",\"updated_at\":\"2022-09-15T09:34:57.894Z\"},\"execute_environments\":[{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}]}}"
+            "text": "{\"id\":\"7gtPjM\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T09:35:38.921Z\",\"updated_at\":\"2023-03-10T08:17:01.953Z\",\"build\":{\"id\":\"d1ulrD\",\"name\":\"Sunflower\",\"version\":\"0.1.6 1\",\"created_at\":\"2022-09-15T09:34:57.606Z\",\"updated_at\":\"2022-09-15T09:34:57.894Z\"},\"execute_environments\":[{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}]}}"
           },
           "cookies": [],
           "headers": [],
@@ -41,8 +41,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2023-03-09T09:31:09.660Z",
-        "time": 725,
+        "startedDateTime": "2023-03-10T08:17:01.370Z",
+        "time": 730,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -50,7 +50,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 725
+          "wait": 730
         }
       }
     ],

--- a/integration-test/__recordings__/mobile%20test%20run%20--build-path%3Dandroid.apk%20--wait%20https%3A%2F%2Fmobile-app.autify.com%2Fprojects%2F4yyFEL%2Ftest_plans%2FWptd97/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/mobile%20test%20run%20--build-path%3Dandroid.apk%20--wait%20https%3A%2F%2Fmobile-app.autify.com%2Fprojects%2F4yyFEL%2Ftest_plans%2FWptd97/polly-proxy_3343057686/recording.har
@@ -15,11 +15,11 @@
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 403,
+          "headersSize": 404,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
-            "mimeType": "multipart/form-data; boundary=--------------------------574106898957424620913679",
+            "mimeType": "multipart/form-data; boundary=--------------------------104913477943071342780955",
             "params": []
           },
           "queryString": [],
@@ -30,7 +30,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 15,
-            "text": "{\"id\":\"PWuEn9\"}"
+            "text": "{\"id\":\"8DubWy\"}"
           },
           "cookies": [],
           "headers": [],
@@ -40,8 +40,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2023-03-09T09:31:10.228Z",
-        "time": 25957,
+        "startedDateTime": "2023-03-10T08:17:02.104Z",
+        "time": 34857,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -49,24 +49,24 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 25957
+          "wait": 34857
         }
       },
       {
-        "_id": "22c51d5f4a18cf9d9c945a8748a415b3",
+        "_id": "c83afd2ab223176faf71a0da35facae4",
         "_order": 0,
         "cache": {},
         "request": {
           "bodySize": 21,
           "cookies": [],
           "headers": [],
-          "headersSize": 344,
+          "headersSize": 345,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"build_id\":\"PWuEn9\"}"
+            "text": "{\"build_id\":\"8DubWy\"}"
           },
           "queryString": [],
           "url": "https://mobile-app.autify.com/api/v1/test_plans/Wptd97/test_plan_results"
@@ -76,7 +76,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 377,
-            "text": "{\"id\":\"5OtGoX\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T09:35:38.921Z\",\"updated_at\":\"2023-03-09T09:31:37.069Z\",\"build\":{\"id\":\"PWuEn9\",\"name\":\"Sunflower\",\"version\":\"0.1.6 1\",\"created_at\":\"2023-03-09T09:31:35.824Z\",\"updated_at\":\"2023-03-09T09:31:36.105Z\"},\"execute_environments\":[{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}]}}"
+            "text": "{\"id\":\"kAtO3k\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T09:35:38.921Z\",\"updated_at\":\"2023-03-10T08:17:37.778Z\",\"build\":{\"id\":\"8DubWy\",\"name\":\"Sunflower\",\"version\":\"0.1.6 1\",\"created_at\":\"2023-03-10T08:17:36.684Z\",\"updated_at\":\"2023-03-10T08:17:36.883Z\"},\"execute_environments\":[{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}]}}"
           },
           "cookies": [],
           "headers": [],
@@ -86,8 +86,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2023-03-09T09:31:36.204Z",
-        "time": 1115,
+        "startedDateTime": "2023-03-10T08:17:36.985Z",
+        "time": 1063,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -95,29 +95,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1115
+          "wait": 1063
         }
       },
       {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
         "_order": 0,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
         },
         "response": {
           "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 547,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:37.325+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:37.069+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:38.096+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -127,8 +127,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:38.346Z",
-        "time": 786,
+        "startedDateTime": "2023-03-10T08:17:39.074Z",
+        "time": 801,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -136,29 +136,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 786
+          "wait": 801
         }
       },
       {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
         "_order": 1,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
         },
         "response": {
           "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 547,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:37.325+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:37.069+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:38.096+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -168,8 +168,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:39.347Z",
-        "time": 859,
+        "startedDateTime": "2023-03-10T08:17:40.072Z",
+        "time": 772,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -177,29 +177,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 859
+          "wait": 772
         }
       },
       {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
         "_order": 2,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
         },
         "response": {
           "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 547,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:37.325+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:37.069+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:38.096+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -209,8 +209,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:40.346Z",
-        "time": 794,
+        "startedDateTime": "2023-03-10T08:17:41.072Z",
+        "time": 644,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -218,29 +218,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 794
+          "wait": 644
         }
       },
       {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
         "_order": 3,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
         },
         "response": {
           "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 547,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:37.325+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:37.069+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:38.096+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -250,1032 +250,7 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:41.347Z",
-        "time": 845,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 845
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 4,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 547,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 547,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:37.325+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:37.069+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:42.348Z",
-        "time": 597,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 597
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 5,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 547,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 547,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:37.325+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:37.069+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:43.349Z",
-        "time": 813,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 813
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 6,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 547,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 547,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:37.325+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:37.069+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:44.352Z",
-        "time": 612,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 612
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 7,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 547,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 547,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:37.325+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:37.069+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:45.352Z",
-        "time": 786,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 786
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 8,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 547,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 547,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:37.325+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:37.069+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:46.352Z",
-        "time": 807,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 807
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 9,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 547,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 547,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:37.325+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:37.069+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:47.353Z",
-        "time": 851,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 851
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 10,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 547,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 547,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:37.325+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:37.069+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:48.353Z",
-        "time": 605,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 605
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 11,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 547,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 547,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:37.325+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:37.069+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:49.354Z",
-        "time": 562,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 562
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 12,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 547,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 547,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:37.325+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:50.353Z",
-        "time": 592,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 592
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 13,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:51.518+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:51.356Z",
-        "time": 635,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 635
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 14,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:51.518+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:52.356Z",
-        "time": 621,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 621
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 15,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:51.518+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:53.359Z",
-        "time": 561,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 561
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 16,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:51.518+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:54.358Z",
-        "time": 563,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 563
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 17,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:51.518+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:55.359Z",
-        "time": 594,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 594
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 18,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:51.518+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:56.359Z",
-        "time": 564,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 564
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 19,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:51.518+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:57.361Z",
-        "time": 583,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 583
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 20,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:51.518+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:58.362Z",
-        "time": 561,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 561
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 21,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:51.518+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:59.365Z",
-        "time": 549,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 549
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 22,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:51.518+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:00.368Z",
-        "time": 537,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 537
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 23,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:51.518+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:01.366Z",
-        "time": 603,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 603
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 24,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:51.518+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:02.369Z",
-        "time": 543,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 543
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 25,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:51.518+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:03.370Z",
-        "time": 593,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 593
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 26,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:51.518+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:04.373Z",
-        "time": 551,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 551
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 27,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:51.518+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:05.374Z",
-        "time": 559,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 559
-        }
-      },
-      {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 28,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
-        },
-        "response": {
-          "bodySize": 574,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:51.518+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:06.376Z",
+        "startedDateTime": "2023-03-10T08:17:42.075Z",
         "time": 566,
         "timings": {
           "blocked": -1,
@@ -1288,25 +263,25 @@
         }
       },
       {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 29,
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 4,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
         },
         "response": {
-          "bodySize": 574,
+          "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:51.518+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "size": 547,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:38.096+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -1316,8 +291,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:32:07.378Z",
-        "time": 604,
+        "startedDateTime": "2023-03-10T08:17:43.074Z",
+        "time": 582,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1325,29 +300,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 604
+          "wait": 582
         }
       },
       {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 30,
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 5,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
         },
         "response": {
-          "bodySize": 574,
+          "bodySize": 547,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 574,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:51.518+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "size": 547,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:38.096+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -1357,7 +332,253 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:32:08.379Z",
+        "startedDateTime": "2023-03-10T08:17:44.078Z",
+        "time": 589,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 589
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 6,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:38.096+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:45.081Z",
+        "time": 572,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 572
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 7,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:38.096+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:46.082Z",
+        "time": 546,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 546
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 8,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:38.096+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:47.083Z",
+        "time": 578,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 578
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 9,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:38.096+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:48.085Z",
+        "time": 565,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 565
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 10,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:38.096+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:49.087Z",
+        "time": 580,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 580
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 11,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:38.096+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:50.090Z",
         "time": 550,
         "timings": {
           "blocked": -1,
@@ -1370,25 +591,107 @@
         }
       },
       {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
-        "_order": 31,
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 12,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:38.096+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:51.089Z",
+        "time": 599,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 599
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 13,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 547,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:38.096+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:52.091Z",
+        "time": 613,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 613
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 14,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
         },
         "response": {
           "bodySize": 574,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 574,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:31:51.518+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"passed\",\"duration\":16296,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:53.107+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:53.110+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -1398,8 +701,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:32:09.380Z",
-        "time": 627,
+        "startedDateTime": "2023-03-10T08:17:53.092Z",
+        "time": 580,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1407,29 +710,726 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 627
+          "wait": 580
         }
       },
       {
-        "_id": "79f278eabd20f2c68fc152c0c5ccb85d",
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 15,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:53.107+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:53.110+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:54.091Z",
+        "time": 600,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 600
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 16,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:53.107+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:53.110+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:55.093Z",
+        "time": 557,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 557
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 17,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:53.107+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:53.110+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:56.095Z",
+        "time": 559,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 559
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 18,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:53.107+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:53.110+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:57.099Z",
+        "time": 602,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 602
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 19,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:53.107+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:53.110+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:58.100Z",
+        "time": 565,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 565
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 20,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:53.107+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:53.110+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:59.102Z",
+        "time": 565,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 565
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 21,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:53.107+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:53.110+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:00.103Z",
+        "time": 633,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 633
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 22,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:53.107+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:53.110+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:01.106Z",
+        "time": 567,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 567
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 23,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:53.107+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:53.110+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:02.109Z",
+        "time": 543,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 543
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 24,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:53.107+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:53.110+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:03.110Z",
+        "time": 568,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 568
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 25,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:53.107+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:53.110+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:04.112Z",
+        "time": 564,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 564
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 26,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:53.107+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:53.110+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:05.115Z",
+        "time": 550,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 550
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 27,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:53.107+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:53.110+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:06.115Z",
+        "time": 572,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 572
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 28,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:53.107+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:53.110+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:07.116Z",
+        "time": 530,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 530
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 29,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:53.107+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:53.110+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:08.118Z",
+        "time": 616,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 616
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 30,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:53.107+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:53.110+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:09.123Z",
+        "time": 555,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 555
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
+        "_order": 31,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
+        },
+        "response": {
+          "bodySize": 574,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 574,
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:53.107+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:17:53.110+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"passed\",\"duration\":15658,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:10.123Z",
+        "time": 597,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 597
+        }
+      },
+      {
+        "_id": "4d22fe0acbceaa37482f580c2d72f2fa",
         "_order": 32,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/5OtGoX"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/kAtO3k"
         },
         "response": {
           "bodySize": 601,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 601,
-            "text": "{\"id\":\"5OtGoX\",\"status\":\"passed\",\"duration\":16346,\"started_at\":\"2023-03-09T18:31:51.516+09:00\",\"finished_at\":\"2023-03-09T18:32:08.036+09:00\",\"created_at\":\"2023-03-09T18:31:37.152+09:00\",\"updated_at\":\"2023-03-09T18:32:10.404+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-09T18:31:50.531+09:00\"},\"test_case_results\":[{\"id\":\"Q9I3a1Z\",\"status\":\"passed\",\"duration\":16296,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"PWuEn9\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
+            "text": "{\"id\":\"kAtO3k\",\"status\":\"passed\",\"duration\":15705,\"started_at\":\"2023-03-10T17:17:53.107+09:00\",\"finished_at\":\"2023-03-10T17:18:08.984+09:00\",\"created_at\":\"2023-03-10T17:17:37.910+09:00\",\"updated_at\":\"2023-03-10T17:18:10.960+09:00\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T18:35:38.921+09:00\",\"updated_at\":\"2023-03-10T17:17:39.757+09:00\"},\"test_case_results\":[{\"id\":\"LpIyeM7\",\"status\":\"passed\",\"duration\":15658,\"test_case\":{\"id\":\"K8IDP6\",\"environment_variables\":[],\"build\":{\"id\":\"8DubWy\"},\"capability\":{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -1439,8 +1439,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:32:10.381Z",
-        "time": 627,
+        "startedDateTime": "2023-03-10T08:18:11.125Z",
+        "time": 527,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1448,7 +1448,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 627
+          "wait": 527
         }
       }
     ],

--- a/integration-test/__recordings__/mobile%20test%20run%20--build-path%3Dandroid.apk%20https%3A%2F%2Fmobile-app.autify.com%2Fprojects%2F4yyFEL%2Ftest_plans%2FWptd97/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/mobile%20test%20run%20--build-path%3Dandroid.apk%20https%3A%2F%2Fmobile-app.autify.com%2Fprojects%2F4yyFEL%2Ftest_plans%2FWptd97/polly-proxy_3343057686/recording.har
@@ -15,11 +15,11 @@
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 403,
+          "headersSize": 404,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
-            "mimeType": "multipart/form-data; boundary=--------------------------390549551164065964676846",
+            "mimeType": "multipart/form-data; boundary=--------------------------578787592461477291544283",
             "params": []
           },
           "queryString": [],
@@ -30,7 +30,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 15,
-            "text": "{\"id\":\"p7uP7j\"}"
+            "text": "{\"id\":\"XYuLXo\"}"
           },
           "cookies": [],
           "headers": [],
@@ -40,8 +40,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2023-03-09T09:31:10.190Z",
-        "time": 39805,
+        "startedDateTime": "2023-03-10T08:17:01.957Z",
+        "time": 37021,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -49,24 +49,24 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 39805
+          "wait": 37021
         }
       },
       {
-        "_id": "f0aa9245ac2089a8a47bf787815617d5",
+        "_id": "04d234695624da31f3f7b168997ba589",
         "_order": 0,
         "cache": {},
         "request": {
           "bodySize": 21,
           "cookies": [],
           "headers": [],
-          "headersSize": 344,
+          "headersSize": 345,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"build_id\":\"p7uP7j\"}"
+            "text": "{\"build_id\":\"XYuLXo\"}"
           },
           "queryString": [],
           "url": "https://mobile-app.autify.com/api/v1/test_plans/Wptd97/test_plan_results"
@@ -76,7 +76,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 377,
-            "text": "{\"id\":\"xjtv26\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T09:35:38.921Z\",\"updated_at\":\"2023-03-09T09:31:50.531Z\",\"build\":{\"id\":\"p7uP7j\",\"name\":\"Sunflower\",\"version\":\"0.1.6 1\",\"created_at\":\"2023-03-09T09:31:49.702Z\",\"updated_at\":\"2023-03-09T09:31:49.924Z\"},\"execute_environments\":[{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}]}}"
+            "text": "{\"id\":\"rWtvZX\",\"test_plan\":{\"id\":\"Wptd97\",\"name\":\"Autify CLI (Android)\",\"created_at\":\"2022-09-15T09:35:38.921Z\",\"updated_at\":\"2023-03-10T08:17:39.757Z\",\"build\":{\"id\":\"XYuLXo\",\"name\":\"Sunflower\",\"version\":\"0.1.6 1\",\"created_at\":\"2023-03-10T08:17:38.675Z\",\"updated_at\":\"2023-03-10T08:17:38.905Z\"},\"execute_environments\":[{\"os\":\"android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\"}]}}"
           },
           "cookies": [],
           "headers": [],
@@ -86,8 +86,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2023-03-09T09:31:50.013Z",
-        "time": 1244,
+        "startedDateTime": "2023-03-10T08:17:38.998Z",
+        "time": 1381,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -95,7 +95,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1244
+          "wait": 1381
         }
       }
     ],

--- a/integration-test/__recordings__/mobile%20test%20run%20--build-path%3Dios.app%20--wait%20https%3A%2F%2Fmobile-app.autify.com%2Fprojects%2F4yyFEL%2Ftest_plans%2FkYtlRR/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/mobile%20test%20run%20--build-path%3Dios.app%20--wait%20https%3A%2F%2Fmobile-app.autify.com%2Fprojects%2F4yyFEL%2Ftest_plans%2FkYtlRR/polly-proxy_3343057686/recording.har
@@ -15,11 +15,11 @@
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 403,
+          "headersSize": 404,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
-            "mimeType": "multipart/form-data; boundary=--------------------------914287222501084057862519",
+            "mimeType": "multipart/form-data; boundary=--------------------------430869796554230081228147",
             "params": []
           },
           "queryString": [],
@@ -30,7 +30,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 15,
-            "text": "{\"id\":\"VZu42D\"}"
+            "text": "{\"id\":\"K4uP0x\"}"
           },
           "cookies": [],
           "headers": [],
@@ -40,8 +40,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2023-03-09T09:31:11.224Z",
-        "time": 40741,
+        "startedDateTime": "2023-03-10T08:17:02.864Z",
+        "time": 38609,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -49,24 +49,24 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 40741
+          "wait": 38609
         }
       },
       {
-        "_id": "f92e64fd5febc7b19e046151870e0224",
+        "_id": "a407ddd3da319518c08db2327fe7a452",
         "_order": 0,
         "cache": {},
         "request": {
           "bodySize": 21,
           "cookies": [],
           "headers": [],
-          "headersSize": 344,
+          "headersSize": 345,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"build_id\":\"VZu42D\"}"
+            "text": "{\"build_id\":\"K4uP0x\"}"
           },
           "queryString": [],
           "url": "https://mobile-app.autify.com/api/v1/test_plans/kYtlRR/test_plan_results"
@@ -76,7 +76,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 378,
-            "text": "{\"id\":\"2ytGzb\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T09:10:33.076Z\",\"updated_at\":\"2023-03-09T09:31:52.527Z\",\"build\":{\"id\":\"VZu42D\",\"name\":\"playground-ios\",\"version\":\"1.0 2\",\"created_at\":\"2023-03-09T09:31:51.670Z\",\"updated_at\":\"2023-03-09T09:31:51.891Z\"},\"execute_environments\":[{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}]}}"
+            "text": "{\"id\":\"zwtBWw\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T09:10:33.076Z\",\"updated_at\":\"2023-03-10T08:17:42.092Z\",\"build\":{\"id\":\"K4uP0x\",\"name\":\"playground-ios\",\"version\":\"1.0 2\",\"created_at\":\"2023-03-10T08:17:41.156Z\",\"updated_at\":\"2023-03-10T08:17:41.400Z\"},\"execute_environments\":[{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}]}}"
           },
           "cookies": [],
           "headers": [],
@@ -86,8 +86,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2023-03-09T09:31:51.981Z",
-        "time": 656,
+        "startedDateTime": "2023-03-10T08:17:41.498Z",
+        "time": 730,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -95,29 +95,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 656
+          "wait": 730
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
+        "_id": "caba2581595c65e114d09bc796a64682",
         "_order": 0,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
-          "bodySize": 545,
+          "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -127,8 +127,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:53.673Z",
-        "time": 618,
+        "startedDateTime": "2023-03-10T08:17:43.259Z",
+        "time": 585,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -136,29 +136,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 618
+          "wait": 585
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
+        "_id": "caba2581595c65e114d09bc796a64682",
         "_order": 1,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
-          "bodySize": 545,
+          "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -168,253 +168,7 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:54.673Z",
-        "time": 577,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 577
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 2,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:55.673Z",
-        "time": 582,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 582
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 3,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:56.676Z",
-        "time": 564,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 564
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 4,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:57.676Z",
-        "time": 536,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 536
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 5,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:58.677Z",
-        "time": 573,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 573
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 6,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:59.680Z",
-        "time": 587,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 587
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 7,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:00.680Z",
+        "startedDateTime": "2023-03-10T08:17:44.258Z",
         "time": 566,
         "timings": {
           "blocked": -1,
@@ -427,25 +181,25 @@
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 8,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 2,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
-          "bodySize": 545,
+          "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -455,8 +209,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:32:01.680Z",
-        "time": 579,
+        "startedDateTime": "2023-03-10T08:17:45.262Z",
+        "time": 576,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -464,29 +218,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 579
+          "wait": 576
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 9,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 3,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
-          "bodySize": 545,
+          "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -496,8 +250,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:32:02.681Z",
-        "time": 568,
+        "startedDateTime": "2023-03-10T08:17:46.262Z",
+        "time": 549,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -505,29 +259,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 568
+          "wait": 549
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 10,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 4,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
-          "bodySize": 545,
+          "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -537,8 +291,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:32:03.683Z",
-        "time": 562,
+        "startedDateTime": "2023-03-10T08:17:47.266Z",
+        "time": 617,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -546,29 +300,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 562
+          "wait": 617
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 11,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 5,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
-          "bodySize": 545,
+          "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -578,48 +332,7 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:32:04.684Z",
-        "time": 582,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 582
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 12,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:05.686Z",
+        "startedDateTime": "2023-03-10T08:17:48.267Z",
         "time": 616,
         "timings": {
           "blocked": -1,
@@ -632,4822 +345,25 @@
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 13,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 6,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:06.685Z",
-        "time": 570,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 570
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 14,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:07.686Z",
-        "time": 544,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 544
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 15,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:08.688Z",
-        "time": 577,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 577
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 16,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:09.691Z",
-        "time": 560,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 560
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 17,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:10.692Z",
-        "time": 662,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 662
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 18,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:11.693Z",
-        "time": 561,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 561
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 19,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:12.694Z",
-        "time": 568,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 568
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 20,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:13.695Z",
-        "time": 593,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 593
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 21,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:14.698Z",
-        "time": 568,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 568
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 22,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:15.700Z",
-        "time": 912,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 912
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 23,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:16.698Z",
-        "time": 595,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 595
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 24,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:17.700Z",
-        "time": 572,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 572
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 25,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:18.702Z",
-        "time": 608,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 608
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 26,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:19.705Z",
-        "time": 556,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 556
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 27,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:20.706Z",
-        "time": 604,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 604
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 28,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:21.705Z",
-        "time": 618,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 618
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 29,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:22.706Z",
-        "time": 544,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 544
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 30,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:23.706Z",
-        "time": 564,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 564
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 31,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:24.707Z",
-        "time": 536,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 536
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 32,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:25.710Z",
-        "time": 557,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 557
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 33,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:26.710Z",
-        "time": 567,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 567
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 34,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:27.713Z",
-        "time": 674,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 674
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 35,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:28.712Z",
-        "time": 551,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 551
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 36,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:29.714Z",
-        "time": 603,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 603
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 37,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:30.714Z",
-        "time": 581,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 581
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 38,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:31.715Z",
-        "time": 560,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 560
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 39,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:32.717Z",
-        "time": 560,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 560
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 40,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:33.721Z",
-        "time": 564,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 564
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 41,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:34.722Z",
-        "time": 555,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 555
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 42,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:35.724Z",
-        "time": 578,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 578
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 43,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:36.725Z",
-        "time": 588,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 588
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 44,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:37.726Z",
-        "time": 562,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 562
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 45,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:38.726Z",
-        "time": 530,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 530
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 46,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:39.731Z",
-        "time": 555,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 555
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 47,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:40.730Z",
-        "time": 549,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 549
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 48,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:41.731Z",
-        "time": 624,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 624
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 49,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:42.733Z",
-        "time": 585,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 585
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 50,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:43.734Z",
-        "time": 549,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 549
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 51,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:44.738Z",
-        "time": 578,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 578
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 52,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:45.741Z",
-        "time": 576,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 576
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 53,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:46.738Z",
-        "time": 557,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 557
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 54,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:47.741Z",
-        "time": 581,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 581
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 55,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:48.742Z",
-        "time": 550,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 550
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 56,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:49.743Z",
-        "time": 527,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 527
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 57,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:50.745Z",
-        "time": 558,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 558
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 58,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:51.747Z",
-        "time": 628,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 628
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 59,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:52.747Z",
-        "time": 552,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 552
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 60,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:53.750Z",
-        "time": 577,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 577
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 61,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:54.750Z",
-        "time": 588,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 588
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 62,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:55.750Z",
-        "time": 579,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 579
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 63,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:56.751Z",
-        "time": 547,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 547
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 64,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:57.754Z",
-        "time": 560,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 560
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 65,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:58.754Z",
-        "time": 547,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 547
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 66,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:32:59.757Z",
-        "time": 576,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 576
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 67,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:00.758Z",
-        "time": 555,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 555
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 68,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:01.759Z",
-        "time": 558,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 558
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 69,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:02.760Z",
-        "time": 635,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 635
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 70,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:03.763Z",
-        "time": 592,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 592
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 71,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:04.762Z",
-        "time": 561,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 561
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 72,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:05.765Z",
-        "time": 583,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 583
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 73,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:06.766Z",
-        "time": 576,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 576
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 74,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:07.766Z",
-        "time": 553,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 553
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 75,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:08.768Z",
-        "time": 568,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 568
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 76,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:09.771Z",
-        "time": 543,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 543
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 77,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:10.771Z",
-        "time": 704,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 704
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 78,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:11.771Z",
-        "time": 591,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 591
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 79,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:12.772Z",
-        "time": 561,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 561
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 80,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:13.774Z",
-        "time": 563,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 563
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 81,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:14.776Z",
-        "time": 543,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 543
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 82,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:15.779Z",
-        "time": 589,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 589
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 83,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:16.778Z",
-        "time": 568,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 568
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 84,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:17.778Z",
-        "time": 571,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 571
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 85,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:18.778Z",
-        "time": 578,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 578
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 86,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:19.781Z",
-        "time": 779,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 779
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 87,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:20.781Z",
-        "time": 527,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 527
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 88,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:21.784Z",
-        "time": 584,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 584
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 89,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:22.785Z",
-        "time": 565,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 565
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 90,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:23.786Z",
-        "time": 557,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 557
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 91,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:24.788Z",
-        "time": 597,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 597
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 92,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:25.790Z",
-        "time": 761,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 761
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 93,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:26.790Z",
-        "time": 543,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 543
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 94,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:27.790Z",
-        "time": 558,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 558
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 95,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:28.790Z",
-        "time": 591,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 591
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 96,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:29.790Z",
-        "time": 567,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 567
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 97,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:30.790Z",
-        "time": 579,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 579
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 98,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:31.791Z",
-        "time": 595,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 595
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 99,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:32.794Z",
-        "time": 555,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 555
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 100,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:33.797Z",
-        "time": 1668,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 1668
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 101,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:35.475Z",
-        "time": 558,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 558
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 102,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:36.040Z",
-        "time": 656,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 656
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 103,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:36.805Z",
-        "time": 564,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 564
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 104,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:37.807Z",
-        "time": 576,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 576
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 105,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:38.807Z",
-        "time": 721,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 721
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 106,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:39.809Z",
-        "time": 593,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 593
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 107,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:40.810Z",
-        "time": 569,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 569
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 108,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:41.810Z",
-        "time": 604,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 604
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 109,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:42.811Z",
-        "time": 575,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 575
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 110,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:43.813Z",
-        "time": 571,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 571
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 111,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:44.814Z",
-        "time": 557,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 557
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 112,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:45.817Z",
-        "time": 605,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 605
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 113,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:46.816Z",
-        "time": 581,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 581
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 114,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:47.820Z",
-        "time": 548,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 548
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 115,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:48.820Z",
-        "time": 560,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 560
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 116,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:49.821Z",
-        "time": 590,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 590
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 117,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:50.822Z",
-        "time": 2976,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 2976
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 118,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:53.806Z",
-        "time": 577,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 577
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 119,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:54.390Z",
-        "time": 622,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 622
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 120,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:55.018Z",
-        "time": 1181,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 1181
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 121,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:56.208Z",
-        "time": 587,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 587
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 122,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:56.801Z",
-        "time": 548,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 548
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 123,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:57.357Z",
-        "time": 557,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 557
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 124,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:57.920Z",
-        "time": 568,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 568
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 125,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:58.832Z",
-        "time": 532,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 532
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 126,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:33:59.834Z",
-        "time": 555,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 555
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 127,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:00.838Z",
-        "time": 583,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 583
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 128,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:01.839Z",
-        "time": 565,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 565
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 129,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 545,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 545,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:31:52.780+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"waiting\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:02.843Z",
-        "time": 653,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 653
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 130,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
           "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -5457,8 +373,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:34:03.846Z",
-        "time": 678,
+        "startedDateTime": "2023-03-10T08:17:49.272Z",
+        "time": 1935,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5466,29 +382,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 678
+          "wait": 1935
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 131,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 7,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
           "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -5498,1975 +414,7 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:34:04.845Z",
-        "time": 573,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 573
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 132,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:05.846Z",
-        "time": 540,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 540
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 133,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:06.849Z",
-        "time": 3161,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 3161
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 134,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:10.018Z",
-        "time": 737,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 737
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 135,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:10.761Z",
-        "time": 573,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 573
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 136,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:11.342Z",
-        "time": 603,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 603
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 137,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:11.951Z",
-        "time": 608,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 608
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 138,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:12.567Z",
-        "time": 554,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 554
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 139,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:13.129Z",
-        "time": 632,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 632
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 140,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:13.858Z",
-        "time": 574,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 574
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 141,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:14.858Z",
-        "time": 530,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 530
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 142,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:15.858Z",
-        "time": 578,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 578
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 143,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:16.860Z",
-        "time": 587,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 587
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 144,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:17.862Z",
-        "time": 744,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 744
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 145,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:18.864Z",
-        "time": 585,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 585
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 146,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:19.867Z",
-        "time": 585,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 585
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 147,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:20.868Z",
-        "time": 753,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 753
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 148,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:21.868Z",
-        "time": 558,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 558
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 149,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:22.870Z",
-        "time": 579,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 579
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 150,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:23.873Z",
-        "time": 583,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 583
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 151,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:24.875Z",
-        "time": 563,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 563
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 152,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:25.874Z",
-        "time": 551,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 551
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 153,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:26.875Z",
-        "time": 592,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 592
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 154,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:27.879Z",
-        "time": 577,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 577
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 155,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:28.881Z",
-        "time": 568,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 568
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 156,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:29.882Z",
-        "time": 576,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 576
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 157,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:30.882Z",
-        "time": 570,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 570
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 158,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:31.884Z",
-        "time": 543,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 543
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 159,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:32.887Z",
-        "time": 559,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 559
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 160,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:33.890Z",
-        "time": 555,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 555
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 161,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:34.890Z",
-        "time": 545,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 545
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 162,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:35.891Z",
-        "time": 574,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 574
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 163,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:36.894Z",
-        "time": 563,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 563
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 164,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:37.894Z",
-        "time": 537,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 537
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 165,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:38.894Z",
-        "time": 563,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 563
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 166,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:39.898Z",
-        "time": 584,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 584
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 167,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:40.897Z",
-        "time": 542,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 542
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 168,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:41.899Z",
-        "time": 572,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 572
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 169,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:42.903Z",
-        "time": 565,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 565
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 170,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:43.902Z",
-        "time": 591,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 591
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 171,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:44.903Z",
-        "time": 561,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 561
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 172,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:45.904Z",
-        "time": 563,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 563
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 173,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:46.906Z",
-        "time": 574,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 574
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 174,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:47.908Z",
-        "time": 557,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 557
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 175,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:48.910Z",
-        "time": 550,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 550
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 176,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:49.910Z",
-        "time": 576,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 576
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 177,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:50.910Z",
-        "time": 561,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 561
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 178,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:51.913Z",
-        "time": 594,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 594
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 179,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:52.915Z",
+        "startedDateTime": "2023-03-10T08:17:51.217Z",
         "time": 538,
         "timings": {
           "blocked": -1,
@@ -7479,25 +427,25 @@
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 180,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 8,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
           "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -7507,8 +455,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:34:53.915Z",
-        "time": 566,
+        "startedDateTime": "2023-03-10T08:17:51.763Z",
+        "time": 564,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7516,29 +464,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 566
+          "wait": 564
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 181,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 9,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
           "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -7548,8 +496,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:34:54.916Z",
-        "time": 584,
+        "startedDateTime": "2023-03-10T08:17:52.334Z",
+        "time": 574,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7557,29 +505,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 584
+          "wait": 574
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 182,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 10,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
           "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -7589,8 +537,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:34:55.917Z",
-        "time": 553,
+        "startedDateTime": "2023-03-10T08:17:53.276Z",
+        "time": 562,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7598,29 +546,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 553
+          "wait": 562
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 183,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 11,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
           "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -7630,8 +578,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:34:56.919Z",
-        "time": 553,
+        "startedDateTime": "2023-03-10T08:17:54.277Z",
+        "time": 560,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7639,29 +587,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 553
+          "wait": 560
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 184,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 12,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
           "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -7671,540 +619,7 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:34:57.922Z",
-        "time": 540,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 540
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 185,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:58.924Z",
-        "time": 573,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 573
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 186,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:34:59.926Z",
-        "time": 546,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 546
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 187,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:35:00.926Z",
-        "time": 535,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 535
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 188,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:35:01.927Z",
-        "time": 589,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 589
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 189,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:35:02.929Z",
-        "time": 534,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 534
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 190,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:35:03.930Z",
-        "time": 566,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 566
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 191,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:35:04.930Z",
-        "time": 542,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 542
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 192,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:35:05.932Z",
-        "time": 552,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 552
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 193,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:35:06.933Z",
-        "time": 649,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 649
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 194,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:35:07.934Z",
-        "time": 559,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 559
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 195,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:35:08.938Z",
-        "time": 578,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 578
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 196,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:35:09.940Z",
-        "time": 547,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 547
-        }
-      },
-      {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 197,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
-        },
-        "response": {
-          "bodySize": 572,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 635,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:35:10.939Z",
+        "startedDateTime": "2023-03-10T08:17:55.277Z",
         "time": 570,
         "timings": {
           "blocked": -1,
@@ -8217,25 +632,25 @@
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 198,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 13,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
           "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -8245,8 +660,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:35:11.942Z",
-        "time": 561,
+        "startedDateTime": "2023-03-10T08:17:56.277Z",
+        "time": 560,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8254,29 +669,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 561
+          "wait": 560
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 199,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 14,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
           "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -8286,8 +701,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:35:12.942Z",
-        "time": 610,
+        "startedDateTime": "2023-03-10T08:17:57.279Z",
+        "time": 540,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8295,29 +710,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 610
+          "wait": 540
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 200,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 15,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
           "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -8327,8 +742,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:35:13.945Z",
-        "time": 553,
+        "startedDateTime": "2023-03-10T08:17:58.281Z",
+        "time": 580,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8336,29 +751,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 553
+          "wait": 580
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 201,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 16,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
           "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -8368,8 +783,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:35:14.946Z",
-        "time": 566,
+        "startedDateTime": "2023-03-10T08:17:59.283Z",
+        "time": 594,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8377,29 +792,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 566
+          "wait": 594
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 202,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 17,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
           "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 572,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -8409,7 +824,130 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:35:15.947Z",
+        "startedDateTime": "2023-03-10T08:18:00.289Z",
+        "time": 569,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 569
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 18,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:01.291Z",
+        "time": 597,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 597
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 19,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:02.291Z",
+        "time": 555,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 555
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 20,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:03.296Z",
         "time": 574,
         "timings": {
           "blocked": -1,
@@ -8422,25 +960,25 @@
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 203,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 21,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
-          "bodySize": 571,
+          "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 571,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"passed\",\"duration\":4900,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -8450,8 +988,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:35:16.949Z",
-        "time": 574,
+        "startedDateTime": "2023-03-10T08:18:04.292Z",
+        "time": 591,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8459,29 +997,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 574
+          "wait": 591
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 204,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 22,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
-          "bodySize": 571,
+          "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 571,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"passed\",\"duration\":4900,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -8491,8 +1029,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:35:17.952Z",
-        "time": 556,
+        "startedDateTime": "2023-03-10T08:18:05.298Z",
+        "time": 529,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8500,29 +1038,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 556
+          "wait": 529
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 205,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 23,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
-          "bodySize": 571,
+          "bodySize": 572,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 571,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:34:03.529+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"passed\",\"duration\":4900,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -8532,8 +1070,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:35:18.955Z",
-        "time": 553,
+        "startedDateTime": "2023-03-10T08:18:06.296Z",
+        "time": 594,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8541,29 +1079,2079 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 553
+          "wait": 594
         }
       },
       {
-        "_id": "fdbcc337199b9d8701521cf83f7f559d",
-        "_order": 206,
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 24,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 286,
+          "headersSize": 287,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/2ytGzb"
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:07.300Z",
+        "time": 546,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 546
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 25,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:08.303Z",
+        "time": 572,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 572
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 26,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:09.305Z",
+        "time": 554,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 554
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 27,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:10.307Z",
+        "time": 608,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 608
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 28,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:11.306Z",
+        "time": 550,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 550
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 29,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:12.308Z",
+        "time": 583,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 583
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 30,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:13.308Z",
+        "time": 573,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 573
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 31,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:14.313Z",
+        "time": 564,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 564
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 32,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:15.314Z",
+        "time": 573,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 573
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 33,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:16.315Z",
+        "time": 578,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 578
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 34,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:17.315Z",
+        "time": 582,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 582
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 35,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:18.319Z",
+        "time": 559,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 559
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 36,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:19.321Z",
+        "time": 612,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 612
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 37,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:20.320Z",
+        "time": 604,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 604
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 38,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:21.324Z",
+        "time": 571,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 571
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 39,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:22.325Z",
+        "time": 628,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 628
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 40,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:23.329Z",
+        "time": 543,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 543
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 41,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:24.329Z",
+        "time": 551,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 551
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 42,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:25.331Z",
+        "time": 587,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 587
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 43,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:26.334Z",
+        "time": 577,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 577
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 44,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:27.336Z",
+        "time": 579,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 579
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 45,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:28.338Z",
+        "time": 614,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 614
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 46,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:29.340Z",
+        "time": 564,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 564
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 47,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:30.341Z",
+        "time": 596,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 596
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 48,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:31.343Z",
+        "time": 544,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 544
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 49,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:32.347Z",
+        "time": 543,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 543
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 50,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:33.347Z",
+        "time": 586,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 586
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 51,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:34.349Z",
+        "time": 583,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 583
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 52,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:35.351Z",
+        "time": 550,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 550
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 53,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:36.355Z",
+        "time": 564,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 564
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 54,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:37.355Z",
+        "time": 576,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 576
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 55,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:38.356Z",
+        "time": 534,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 534
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 56,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:39.361Z",
+        "time": 541,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 541
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 57,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:40.362Z",
+        "time": 547,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 547
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 58,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:41.363Z",
+        "time": 569,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 569
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 59,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:42.365Z",
+        "time": 535,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 535
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 60,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:43.370Z",
+        "time": 558,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 558
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 61,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:44.372Z",
+        "time": 546,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 546
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 62,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:45.372Z",
+        "time": 547,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 547
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 63,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:46.373Z",
+        "time": 533,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 533
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 64,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:47.374Z",
+        "time": 579,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 579
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 65,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:48.375Z",
+        "time": 569,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 569
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 66,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:49.376Z",
+        "time": 569,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 569
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 67,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:50.377Z",
+        "time": 680,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 680
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 68,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:51.380Z",
+        "time": 552,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 552
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 69,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:52.382Z",
+        "time": 560,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 560
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 70,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 572,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 572,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"running\",\"duration\":null,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:53.385Z",
+        "time": 559,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 559
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 71,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 571,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 571,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"passed\",\"duration\":4920,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:54.388Z",
+        "time": 598,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 598
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 72,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 571,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 571,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"passed\",\"duration\":4920,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:55.389Z",
+        "time": 567,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 567
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 73,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
+        },
+        "response": {
+          "bodySize": 571,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 571,
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":null,\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:17:42.839+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"passed\",\"duration\":4920,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 635,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:18:56.389Z",
+        "time": 571,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 571
+        }
+      },
+      {
+        "_id": "caba2581595c65e114d09bc796a64682",
+        "_order": 74,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 287,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://mobile-app.autify.com/api/v1/projects/4yyFEL/results/zwtBWw"
         },
         "response": {
           "bodySize": 598,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 598,
-            "text": "{\"id\":\"2ytGzb\",\"status\":\"passed\",\"duration\":72289,\"started_at\":\"2023-03-09T18:34:03.504+09:00\",\"finished_at\":\"2023-03-09T18:35:15.794+09:00\",\"created_at\":\"2023-03-09T18:31:52.542+09:00\",\"updated_at\":\"2023-03-09T18:35:20.216+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-09T18:31:52.527+09:00\"},\"test_case_results\":[{\"id\":\"oKIe1Md\",\"status\":\"passed\",\"duration\":4900,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"VZu42D\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
+            "text": "{\"id\":\"zwtBWw\",\"status\":\"passed\",\"duration\":71226,\"started_at\":\"2023-03-10T17:17:42.805+09:00\",\"finished_at\":\"2023-03-10T17:18:54.032+09:00\",\"created_at\":\"2023-03-10T17:17:42.121+09:00\",\"updated_at\":\"2023-03-10T17:18:57.454+09:00\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T18:10:33.076+09:00\",\"updated_at\":\"2023-03-10T17:17:43.262+09:00\"},\"test_case_results\":[{\"id\":\"yNIyXWd\",\"status\":\"passed\",\"duration\":4920,\"test_case\":{\"id\":\"xjIKdP\",\"environment_variables\":[],\"build\":{\"id\":\"K4uP0x\"},\"capability\":{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}}}]}"
           },
           "cookies": [],
           "headers": [],
@@ -8573,8 +3161,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:35:19.954Z",
-        "time": 593,
+        "startedDateTime": "2023-03-10T08:18:57.392Z",
+        "time": 581,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8582,7 +3170,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 593
+          "wait": 581
         }
       }
     ],

--- a/integration-test/__recordings__/mobile%20test%20run%20--build-path%3Dios.app%20https%3A%2F%2Fmobile-app.autify.com%2Fprojects%2F4yyFEL%2Ftest_plans%2FkYtlRR/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/mobile%20test%20run%20--build-path%3Dios.app%20https%3A%2F%2Fmobile-app.autify.com%2Fprojects%2F4yyFEL%2Ftest_plans%2FkYtlRR/polly-proxy_3343057686/recording.har
@@ -15,11 +15,11 @@
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 403,
+          "headersSize": 404,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
-            "mimeType": "multipart/form-data; boundary=--------------------------266211554085919713646989",
+            "mimeType": "multipart/form-data; boundary=--------------------------649903404927093753605424",
             "params": []
           },
           "queryString": [],
@@ -30,7 +30,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 15,
-            "text": "{\"id\":\"mKuXKP\"}"
+            "text": "{\"id\":\"e6u97o\"}"
           },
           "cookies": [],
           "headers": [],
@@ -40,8 +40,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2023-03-09T09:31:11.087Z",
-        "time": 39442,
+        "startedDateTime": "2023-03-10T08:17:03.050Z",
+        "time": 39655,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -49,24 +49,24 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 39442
+          "wait": 39655
         }
       },
       {
-        "_id": "83bd31a0a3329da71f105c6503b27b95",
+        "_id": "bd47087e0366158f123266056cec903d",
         "_order": 0,
         "cache": {},
         "request": {
           "bodySize": 21,
           "cookies": [],
           "headers": [],
-          "headersSize": 344,
+          "headersSize": 345,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"build_id\":\"mKuXKP\"}"
+            "text": "{\"build_id\":\"e6u97o\"}"
           },
           "queryString": [],
           "url": "https://mobile-app.autify.com/api/v1/test_plans/kYtlRR/test_plan_results"
@@ -76,7 +76,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 378,
-            "text": "{\"id\":\"3Jt3lj\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T09:10:33.076Z\",\"updated_at\":\"2023-03-09T09:31:51.123Z\",\"build\":{\"id\":\"mKuXKP\",\"name\":\"playground-ios\",\"version\":\"1.0 2\",\"created_at\":\"2023-03-09T09:31:50.179Z\",\"updated_at\":\"2023-03-09T09:31:50.453Z\"},\"execute_environments\":[{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}]}}"
+            "text": "{\"id\":\"AAtexl\",\"test_plan\":{\"id\":\"kYtlRR\",\"name\":\"Autify CLI (iOS)\",\"created_at\":\"2022-09-15T09:10:33.076Z\",\"updated_at\":\"2023-03-10T08:17:43.262Z\",\"build\":{\"id\":\"e6u97o\",\"name\":\"playground-ios\",\"version\":\"1.0 2\",\"created_at\":\"2023-03-10T08:17:42.331Z\",\"updated_at\":\"2023-03-10T08:17:42.628Z\"},\"execute_environments\":[{\"os\":\"iOS\",\"os_version\":\"14.4\",\"device\":\"iPhone 12 Pro\"}]}}"
           },
           "cookies": [],
           "headers": [],
@@ -86,8 +86,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2023-03-09T09:31:50.546Z",
-        "time": 707,
+        "startedDateTime": "2023-03-10T08:17:42.723Z",
+        "time": 662,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -95,7 +95,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 707
+          "wait": 662
         }
       }
     ],

--- a/integration-test/__recordings__/web%20test%20run%20--autify-connect-client%20--wait%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Fscenarios%2F91437/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/web%20test%20run%20--autify-connect-client%20--wait%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Fscenarios%2F91437/polly-proxy_3343057686/recording.har
@@ -15,13 +15,13 @@
           "bodySize": 58,
           "cookies": [],
           "headers": [],
-          "headersSize": 340,
+          "headersSize": 341,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"name\":\"autify-cli-4dc0ee76-5a5c-4d83-922f-31ad256c735c\"}"
+            "text": "{\"name\":\"autify-cli-8ad2c8cf-df9d-4449-b0f8-352c34426896\"}"
           },
           "queryString": [],
           "url": "https://app.autify.com/api/v1/projects/743/autify_connect/access_points"
@@ -31,7 +31,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 222,
-            "text": "{\"name\":\"autify-cli-4dc0ee76-5a5c-4d83-922f-31ad256c735c\",\"key\":\"000000000000000000000000000000\",\"last_use\":null,\"creator\":\"nate-autify-live\",\"created_at\":\"2023-03-09T09:31:10.286Z\",\"updated_at\":\"2023-03-09T09:31:10.286Z\"}"
+            "text": "{\"name\":\"autify-cli-8ad2c8cf-df9d-4449-b0f8-352c34426896\",\"key\":\"000000000000000000000000000000\",\"last_use\":null,\"creator\":\"nate-autify-live\",\"created_at\":\"2023-03-10T08:17:02.364Z\",\"updated_at\":\"2023-03-10T08:17:02.364Z\"}"
           },
           "cookies": [],
           "headers": [],
@@ -41,8 +41,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:09.898Z",
-        "time": 410,
+        "startedDateTime": "2023-03-10T08:17:01.704Z",
+        "time": 685,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -50,7 +50,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 410
+          "wait": 685
         }
       },
       {
@@ -61,7 +61,7 @@
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 271,
+          "headersSize": 272,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
@@ -76,7 +76,7 @@
           },
           "cookies": [
             {
-              "expires": "2043-03-09T09:31:11.000Z",
+              "expires": "2043-03-10T08:17:03.000Z",
               "httpOnly": true,
               "name": "current_project_id",
               "path": "/",
@@ -91,8 +91,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:10.821Z",
-        "time": 293,
+        "startedDateTime": "2023-03-10T08:17:03.022Z",
+        "time": 473,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -100,24 +100,24 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 293
+          "wait": 473
         }
       },
       {
-        "_id": "bfadc338408c689539dee1965000d5b8",
+        "_id": "fb75133328e70dc58ddbd97e4b170dfe",
         "_order": 0,
         "cache": {},
         "request": {
           "bodySize": 272,
           "cookies": [],
           "headers": [],
-          "headersSize": 330,
+          "headersSize": 331,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"capabilities\":[{\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"device_type\":null,\"unsupported\":false}],\"scenarios\":[{\"id\":91437}],\"url_replacements\":[],\"autify_connect\":{\"name\":\"autify-cli-4dc0ee76-5a5c-4d83-922f-31ad256c735c\"}}"
+            "text": "{\"capabilities\":[{\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"device_type\":null,\"unsupported\":false}],\"scenarios\":[{\"id\":91437}],\"url_replacements\":[],\"autify_connect\":{\"name\":\"autify-cli-8ad2c8cf-df9d-4449-b0f8-352c34426896\"}}"
           },
           "queryString": [],
           "url": "https://app.autify.com/api/v1/projects/743/execute_scenarios"
@@ -127,7 +127,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 21,
-            "text": "{\"result_id\":1818292}"
+            "text": "{\"result_id\":1822041}"
           },
           "cookies": [],
           "headers": [],
@@ -137,171 +137,7 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:11.121Z",
-        "time": 668,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 668
-        }
-      },
-      {
-        "_id": "0907dbe3711f8bc7c57e6a1d6f239523",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818292"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1818292,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.724Z\",\"updated_at\":\"2023-03-09T09:31:12.989Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146517,\"capability\":{\"id\":573874,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:11.685Z\",\"updated_at\":\"2023-03-09T09:31:11.685Z\"},\"test_case_results\":[{\"id\":6516485,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.355Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818292/capabilities/2146517/scenarios/6516485\",\"updated_at\":\"2023-03-09T09:31:12.996Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:12.812Z",
-        "time": 472,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 472
-        }
-      },
-      {
-        "_id": "0907dbe3711f8bc7c57e6a1d6f239523",
-        "_order": 1,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818292"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1818292,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.724Z\",\"updated_at\":\"2023-03-09T09:31:12.989Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146517,\"capability\":{\"id\":573874,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:11.685Z\",\"updated_at\":\"2023-03-09T09:31:11.685Z\"},\"test_case_results\":[{\"id\":6516485,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.355Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818292/capabilities/2146517/scenarios/6516485\",\"updated_at\":\"2023-03-09T09:31:12.996Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:13.814Z",
-        "time": 298,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 298
-        }
-      },
-      {
-        "_id": "0907dbe3711f8bc7c57e6a1d6f239523",
-        "_order": 2,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818292"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1818292,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.724Z\",\"updated_at\":\"2023-03-09T09:31:12.989Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146517,\"capability\":{\"id\":573874,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:11.685Z\",\"updated_at\":\"2023-03-09T09:31:11.685Z\"},\"test_case_results\":[{\"id\":6516485,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.355Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818292/capabilities/2146517/scenarios/6516485\",\"updated_at\":\"2023-03-09T09:31:12.996Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:14.815Z",
-        "time": 423,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 423
-        }
-      },
-      {
-        "_id": "0907dbe3711f8bc7c57e6a1d6f239523",
-        "_order": 3,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818292"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1818292,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.724Z\",\"updated_at\":\"2023-03-09T09:31:12.989Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146517,\"capability\":{\"id\":573874,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:11.685Z\",\"updated_at\":\"2023-03-09T09:31:11.685Z\"},\"test_case_results\":[{\"id\":6516485,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.355Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818292/capabilities/2146517/scenarios/6516485\",\"updated_at\":\"2023-03-09T09:31:12.996Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:15.817Z",
+        "startedDateTime": "2023-03-10T08:17:03.506Z",
         "time": 451,
         "timings": {
           "blocked": -1,
@@ -314,25 +150,189 @@
         }
       },
       {
-        "_id": "0907dbe3711f8bc7c57e6a1d6f239523",
+        "_id": "71eaaa7a6532f258952c04e695b6ec71",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822041"
+        },
+        "response": {
+          "bodySize": 829,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 829,
+            "text": "{\"id\":1822041,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:03.927Z\",\"updated_at\":\"2023-03-10T08:17:04.849Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151014,\"capability\":{\"id\":574751,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:03.916Z\",\"updated_at\":\"2023-03-10T08:17:03.916Z\"},\"test_case_results\":[{\"id\":6531516,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:04.534Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822041/capabilities/2151014/scenarios/6531516\",\"updated_at\":\"2023-03-10T08:17:04.961Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:04.986Z",
+        "time": 397,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 397
+        }
+      },
+      {
+        "_id": "71eaaa7a6532f258952c04e695b6ec71",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822041"
+        },
+        "response": {
+          "bodySize": 829,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 829,
+            "text": "{\"id\":1822041,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:03.927Z\",\"updated_at\":\"2023-03-10T08:17:04.849Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151014,\"capability\":{\"id\":574751,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:03.916Z\",\"updated_at\":\"2023-03-10T08:17:03.916Z\"},\"test_case_results\":[{\"id\":6531516,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:04.534Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822041/capabilities/2151014/scenarios/6531516\",\"updated_at\":\"2023-03-10T08:17:04.961Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:05.988Z",
+        "time": 374,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 374
+        }
+      },
+      {
+        "_id": "71eaaa7a6532f258952c04e695b6ec71",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822041"
+        },
+        "response": {
+          "bodySize": 829,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 829,
+            "text": "{\"id\":1822041,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:03.927Z\",\"updated_at\":\"2023-03-10T08:17:04.849Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151014,\"capability\":{\"id\":574751,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:03.916Z\",\"updated_at\":\"2023-03-10T08:17:03.916Z\"},\"test_case_results\":[{\"id\":6531516,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:04.534Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822041/capabilities/2151014/scenarios/6531516\",\"updated_at\":\"2023-03-10T08:17:04.961Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:06.991Z",
+        "time": 419,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 419
+        }
+      },
+      {
+        "_id": "71eaaa7a6532f258952c04e695b6ec71",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822041"
+        },
+        "response": {
+          "bodySize": 829,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 829,
+            "text": "{\"id\":1822041,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:03.927Z\",\"updated_at\":\"2023-03-10T08:17:04.849Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151014,\"capability\":{\"id\":574751,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:03.916Z\",\"updated_at\":\"2023-03-10T08:17:03.916Z\"},\"test_case_results\":[{\"id\":6531516,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:04.534Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822041/capabilities/2151014/scenarios/6531516\",\"updated_at\":\"2023-03-10T08:17:04.961Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:07.991Z",
+        "time": 335,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 335
+        }
+      },
+      {
+        "_id": "71eaaa7a6532f258952c04e695b6ec71",
         "_order": 4,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818292"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822041"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1818292,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.724Z\",\"updated_at\":\"2023-03-09T09:31:12.989Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146517,\"capability\":{\"id\":573874,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:11.685Z\",\"updated_at\":\"2023-03-09T09:31:11.685Z\"},\"test_case_results\":[{\"id\":6516485,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.355Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818292/capabilities/2146517/scenarios/6516485\",\"updated_at\":\"2023-03-09T09:31:12.996Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1822041,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:03.927Z\",\"updated_at\":\"2023-03-10T08:17:04.849Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151014,\"capability\":{\"id\":574751,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:03.916Z\",\"updated_at\":\"2023-03-10T08:17:03.916Z\"},\"test_case_results\":[{\"id\":6531516,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:04.534Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822041/capabilities/2151014/scenarios/6531516\",\"updated_at\":\"2023-03-10T08:17:04.961Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -342,8 +342,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:16.819Z",
-        "time": 458,
+        "startedDateTime": "2023-03-10T08:17:08.992Z",
+        "time": 415,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -351,29 +351,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 458
+          "wait": 415
         }
       },
       {
-        "_id": "0907dbe3711f8bc7c57e6a1d6f239523",
+        "_id": "71eaaa7a6532f258952c04e695b6ec71",
         "_order": 5,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818292"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822041"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1818292,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.724Z\",\"updated_at\":\"2023-03-09T09:31:12.989Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146517,\"capability\":{\"id\":573874,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:11.685Z\",\"updated_at\":\"2023-03-09T09:31:11.685Z\"},\"test_case_results\":[{\"id\":6516485,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.355Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818292/capabilities/2146517/scenarios/6516485\",\"updated_at\":\"2023-03-09T09:31:12.996Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1822041,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:03.927Z\",\"updated_at\":\"2023-03-10T08:17:04.849Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151014,\"capability\":{\"id\":574751,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:03.916Z\",\"updated_at\":\"2023-03-10T08:17:03.916Z\"},\"test_case_results\":[{\"id\":6531516,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:04.534Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822041/capabilities/2151014/scenarios/6531516\",\"updated_at\":\"2023-03-10T08:17:04.961Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -383,8 +383,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:17.822Z",
-        "time": 456,
+        "startedDateTime": "2023-03-10T08:17:09.994Z",
+        "time": 417,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -392,29 +392,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 456
+          "wait": 417
         }
       },
       {
-        "_id": "0907dbe3711f8bc7c57e6a1d6f239523",
+        "_id": "71eaaa7a6532f258952c04e695b6ec71",
         "_order": 6,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818292"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822041"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1818292,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.724Z\",\"updated_at\":\"2023-03-09T09:31:12.989Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146517,\"capability\":{\"id\":573874,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:11.685Z\",\"updated_at\":\"2023-03-09T09:31:11.685Z\"},\"test_case_results\":[{\"id\":6516485,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.355Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818292/capabilities/2146517/scenarios/6516485\",\"updated_at\":\"2023-03-09T09:31:12.996Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1822041,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:03.927Z\",\"updated_at\":\"2023-03-10T08:17:04.849Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151014,\"capability\":{\"id\":574751,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:03.916Z\",\"updated_at\":\"2023-03-10T08:17:03.916Z\"},\"test_case_results\":[{\"id\":6531516,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:04.534Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822041/capabilities/2151014/scenarios/6531516\",\"updated_at\":\"2023-03-10T08:17:04.961Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -424,7 +424,212 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:18.823Z",
+        "startedDateTime": "2023-03-10T08:17:10.995Z",
+        "time": 176,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 176
+        }
+      },
+      {
+        "_id": "71eaaa7a6532f258952c04e695b6ec71",
+        "_order": 7,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822041"
+        },
+        "response": {
+          "bodySize": 829,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 829,
+            "text": "{\"id\":1822041,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:03.927Z\",\"updated_at\":\"2023-03-10T08:17:04.849Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151014,\"capability\":{\"id\":574751,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:03.916Z\",\"updated_at\":\"2023-03-10T08:17:03.916Z\"},\"test_case_results\":[{\"id\":6531516,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:04.534Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822041/capabilities/2151014/scenarios/6531516\",\"updated_at\":\"2023-03-10T08:17:04.961Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:11.998Z",
+        "time": 246,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 246
+        }
+      },
+      {
+        "_id": "71eaaa7a6532f258952c04e695b6ec71",
+        "_order": 8,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822041"
+        },
+        "response": {
+          "bodySize": 829,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 829,
+            "text": "{\"id\":1822041,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:03.927Z\",\"updated_at\":\"2023-03-10T08:17:04.849Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151014,\"capability\":{\"id\":574751,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:03.916Z\",\"updated_at\":\"2023-03-10T08:17:03.916Z\"},\"test_case_results\":[{\"id\":6531516,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:04.534Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822041/capabilities/2151014/scenarios/6531516\",\"updated_at\":\"2023-03-10T08:17:04.961Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:12.999Z",
+        "time": 369,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 369
+        }
+      },
+      {
+        "_id": "71eaaa7a6532f258952c04e695b6ec71",
+        "_order": 9,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822041"
+        },
+        "response": {
+          "bodySize": 829,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 829,
+            "text": "{\"id\":1822041,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:03.927Z\",\"updated_at\":\"2023-03-10T08:17:04.849Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151014,\"capability\":{\"id\":574751,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:03.916Z\",\"updated_at\":\"2023-03-10T08:17:03.916Z\"},\"test_case_results\":[{\"id\":6531516,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:04.534Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822041/capabilities/2151014/scenarios/6531516\",\"updated_at\":\"2023-03-10T08:17:04.961Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:13.999Z",
+        "time": 214,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 214
+        }
+      },
+      {
+        "_id": "71eaaa7a6532f258952c04e695b6ec71",
+        "_order": 10,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822041"
+        },
+        "response": {
+          "bodySize": 829,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 829,
+            "text": "{\"id\":1822041,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:03.927Z\",\"updated_at\":\"2023-03-10T08:17:04.849Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151014,\"capability\":{\"id\":574751,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:03.916Z\",\"updated_at\":\"2023-03-10T08:17:03.916Z\"},\"test_case_results\":[{\"id\":6531516,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:04.534Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822041/capabilities/2151014/scenarios/6531516\",\"updated_at\":\"2023-03-10T08:17:04.961Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:15.002Z",
+        "time": 328,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 328
+        }
+      },
+      {
+        "_id": "71eaaa7a6532f258952c04e695b6ec71",
+        "_order": 11,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822041"
+        },
+        "response": {
+          "bodySize": 871,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 871,
+            "text": "{\"id\":1822041,\"status\":\"passed\",\"duration\":8605,\"started_at\":\"2023-03-10T08:17:04.760Z\",\"finished_at\":\"2023-03-10T08:17:13.366Z\",\"created_at\":\"2023-03-10T08:17:03.927Z\",\"updated_at\":\"2023-03-10T08:17:15.884Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151014,\"capability\":{\"id\":574751,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:03.916Z\",\"updated_at\":\"2023-03-10T08:17:03.916Z\"},\"test_case_results\":[{\"id\":6531516,\"test_case_id\":91437,\"status\":\"passed\",\"duration\":4414,\"started_at\":\"2023-03-10T08:17:08.952Z\",\"finished_at\":\"2023-03-10T08:17:13.366Z\",\"created_at\":\"2023-03-10T08:17:04.534Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822041/capabilities/2151014/scenarios/6531516\",\"updated_at\":\"2023-03-10T08:17:15.480Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:16.003Z",
         "time": 404,
         "timings": {
           "blocked": -1,
@@ -437,293 +642,6 @@
         }
       },
       {
-        "_id": "0907dbe3711f8bc7c57e6a1d6f239523",
-        "_order": 7,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818292"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1818292,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.724Z\",\"updated_at\":\"2023-03-09T09:31:12.989Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146517,\"capability\":{\"id\":573874,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:11.685Z\",\"updated_at\":\"2023-03-09T09:31:11.685Z\"},\"test_case_results\":[{\"id\":6516485,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.355Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818292/capabilities/2146517/scenarios/6516485\",\"updated_at\":\"2023-03-09T09:31:12.996Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:19.823Z",
-        "time": 451,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 451
-        }
-      },
-      {
-        "_id": "0907dbe3711f8bc7c57e6a1d6f239523",
-        "_order": 8,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818292"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1818292,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.724Z\",\"updated_at\":\"2023-03-09T09:31:12.989Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146517,\"capability\":{\"id\":573874,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:11.685Z\",\"updated_at\":\"2023-03-09T09:31:11.685Z\"},\"test_case_results\":[{\"id\":6516485,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.355Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818292/capabilities/2146517/scenarios/6516485\",\"updated_at\":\"2023-03-09T09:31:12.996Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:20.827Z",
-        "time": 300,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 300
-        }
-      },
-      {
-        "_id": "0907dbe3711f8bc7c57e6a1d6f239523",
-        "_order": 9,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818292"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1818292,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.724Z\",\"updated_at\":\"2023-03-09T09:31:12.989Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146517,\"capability\":{\"id\":573874,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:11.685Z\",\"updated_at\":\"2023-03-09T09:31:11.685Z\"},\"test_case_results\":[{\"id\":6516485,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.355Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818292/capabilities/2146517/scenarios/6516485\",\"updated_at\":\"2023-03-09T09:31:12.996Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:21.827Z",
-        "time": 484,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 484
-        }
-      },
-      {
-        "_id": "0907dbe3711f8bc7c57e6a1d6f239523",
-        "_order": 10,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818292"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1818292,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.724Z\",\"updated_at\":\"2023-03-09T09:31:12.989Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146517,\"capability\":{\"id\":573874,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:11.685Z\",\"updated_at\":\"2023-03-09T09:31:11.685Z\"},\"test_case_results\":[{\"id\":6516485,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.355Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818292/capabilities/2146517/scenarios/6516485\",\"updated_at\":\"2023-03-09T09:31:12.996Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:22.829Z",
-        "time": 167,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 167
-        }
-      },
-      {
-        "_id": "0907dbe3711f8bc7c57e6a1d6f239523",
-        "_order": 11,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818292"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1818292,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.724Z\",\"updated_at\":\"2023-03-09T09:31:12.989Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146517,\"capability\":{\"id\":573874,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:11.685Z\",\"updated_at\":\"2023-03-09T09:31:11.685Z\"},\"test_case_results\":[{\"id\":6516485,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.355Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818292/capabilities/2146517/scenarios/6516485\",\"updated_at\":\"2023-03-09T09:31:12.996Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:23.830Z",
-        "time": 222,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 222
-        }
-      },
-      {
-        "_id": "0907dbe3711f8bc7c57e6a1d6f239523",
-        "_order": 12,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818292"
-        },
-        "response": {
-          "bodySize": 850,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 850,
-            "text": "{\"id\":1818292,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.724Z\",\"updated_at\":\"2023-03-09T09:31:12.989Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146517,\"capability\":{\"id\":573874,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:11.685Z\",\"updated_at\":\"2023-03-09T09:31:11.685Z\"},\"test_case_results\":[{\"id\":6516485,\"test_case_id\":91437,\"status\":\"passed\",\"duration\":5584,\"started_at\":\"2023-03-09T09:31:17.315Z\",\"finished_at\":\"2023-03-09T09:31:22.899Z\",\"created_at\":\"2023-03-09T09:31:12.355Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818292/capabilities/2146517/scenarios/6516485\",\"updated_at\":\"2023-03-09T09:31:25.182Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:24.832Z",
-        "time": 390,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 390
-        }
-      },
-      {
-        "_id": "0907dbe3711f8bc7c57e6a1d6f239523",
-        "_order": 13,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818292"
-        },
-        "response": {
-          "bodySize": 871,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 871,
-            "text": "{\"id\":1818292,\"status\":\"passed\",\"duration\":9990,\"started_at\":\"2023-03-09T09:31:12.908Z\",\"finished_at\":\"2023-03-09T09:31:22.899Z\",\"created_at\":\"2023-03-09T09:31:11.724Z\",\"updated_at\":\"2023-03-09T09:31:25.549Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146517,\"capability\":{\"id\":573874,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:11.685Z\",\"updated_at\":\"2023-03-09T09:31:11.685Z\"},\"test_case_results\":[{\"id\":6516485,\"test_case_id\":91437,\"status\":\"passed\",\"duration\":5584,\"started_at\":\"2023-03-09T09:31:17.315Z\",\"finished_at\":\"2023-03-09T09:31:22.899Z\",\"created_at\":\"2023-03-09T09:31:12.355Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818292/capabilities/2146517/scenarios/6516485\",\"updated_at\":\"2023-03-09T09:31:25.182Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:25.832Z",
-        "time": 471,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 471
-        }
-      },
-      {
         "_id": "1ac72866dc2e3e0fac4332fdcabc60ed",
         "_order": 0,
         "cache": {},
@@ -731,13 +649,13 @@
           "bodySize": 58,
           "cookies": [],
           "headers": [],
-          "headersSize": 342,
+          "headersSize": 343,
           "httpVersion": "HTTP/1.1",
           "method": "DELETE",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"name\":\"autify-cli-4dc0ee76-5a5c-4d83-922f-31ad256c735c\"}"
+            "text": "{\"name\":\"autify-cli-8ad2c8cf-df9d-4449-b0f8-352c34426896\"}"
           },
           "queryString": [],
           "url": "https://app.autify.com/api/v1/projects/743/autify_connect/access_points"
@@ -757,8 +675,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:27.324Z",
-        "time": 413,
+        "startedDateTime": "2023-03-10T08:17:17.427Z",
+        "time": 483,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -766,7 +684,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 413
+          "wait": 483
         }
       }
     ],

--- a/integration-test/__recordings__/web%20test%20run%20--autify-connect-client%20--wait%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Ftest_plans%2F169408/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/web%20test%20run%20--autify-connect-client%20--wait%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Ftest_plans%2F169408/polly-proxy_3343057686/recording.har
@@ -15,13 +15,13 @@
           "bodySize": 58,
           "cookies": [],
           "headers": [],
-          "headersSize": 340,
+          "headersSize": 341,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"name\":\"autify-cli-a484fe7a-50d0-4805-bd3f-5b489f17c546\"}"
+            "text": "{\"name\":\"autify-cli-96a7357b-44ad-4a50-8ab8-8688303302f4\"}"
           },
           "queryString": [],
           "url": "https://app.autify.com/api/v1/projects/743/autify_connect/access_points"
@@ -31,7 +31,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 222,
-            "text": "{\"name\":\"autify-cli-a484fe7a-50d0-4805-bd3f-5b489f17c546\",\"key\":\"000000000000000000000000000000\",\"last_use\":null,\"creator\":\"nate-autify-live\",\"created_at\":\"2023-03-09T09:31:10.327Z\",\"updated_at\":\"2023-03-09T09:31:10.327Z\"}"
+            "text": "{\"name\":\"autify-cli-96a7357b-44ad-4a50-8ab8-8688303302f4\",\"key\":\"000000000000000000000000000000\",\"last_use\":null,\"creator\":\"nate-autify-live\",\"created_at\":\"2023-03-10T08:17:01.408Z\",\"updated_at\":\"2023-03-10T08:17:01.408Z\"}"
           },
           "cookies": [],
           "headers": [],
@@ -41,8 +41,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:09.931Z",
-        "time": 418,
+        "startedDateTime": "2023-03-10T08:17:00.990Z",
+        "time": 443,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -50,24 +50,24 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 418
+          "wait": 443
         }
       },
       {
-        "_id": "b9ef09b88cc4fd76d5821962f41e786a",
+        "_id": "3df13974ff125c1767110fde60509c68",
         "_order": 0,
         "cache": {},
         "request": {
           "bodySize": 77,
           "cookies": [],
           "headers": [],
-          "headersSize": 315,
+          "headersSize": 316,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"autify_connect\":{\"name\":\"autify-cli-a484fe7a-50d0-4805-bd3f-5b489f17c546\"}}"
+            "text": "{\"autify_connect\":{\"name\":\"autify-cli-96a7357b-44ad-4a50-8ab8-8688303302f4\"}}"
           },
           "queryString": [],
           "url": "https://app.autify.com/api/v1/schedules/169408"
@@ -77,7 +77,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 79,
-            "text": "{\"data\":{\"id\":\"1818291\",\"type\":\"test_plan_result\",\"attributes\":{\"id\":1818291}}}"
+            "text": "{\"data\":{\"id\":\"1822040\",\"type\":\"test_plan_result\",\"attributes\":{\"id\":1822040}}}"
           },
           "cookies": [],
           "headers": [],
@@ -87,8 +87,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:10.907Z",
-        "time": 391,
+        "startedDateTime": "2023-03-10T08:17:02.246Z",
+        "time": 154,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -96,29 +96,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 391
+          "wait": 154
         }
       },
       {
-        "_id": "4d0690855a744f173c0920c96adfa26d",
+        "_id": "f0249bf4f98c0cf5ef28022b6d0e22e8",
         "_order": 0,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818291"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822040"
         },
         "response": {
           "bodySize": 932,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 932,
-            "text": "{\"id\":1818291,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.272Z\",\"updated_at\":\"2023-03-09T09:31:12.404Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146516,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516484,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.041Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818291/capabilities/2146516/scenarios/6516484\",\"updated_at\":\"2023-03-09T09:31:12.516Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+            "text": "{\"id\":1822040,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.377Z\",\"updated_at\":\"2023-03-10T08:17:03.538Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151013,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531515,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.954Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822040/capabilities/2151013/scenarios/6531515\",\"updated_at\":\"2023-03-10T08:17:03.590Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
           },
           "cookies": [],
           "headers": [],
@@ -128,8 +128,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:12.333Z",
-        "time": 462,
+        "startedDateTime": "2023-03-10T08:17:03.422Z",
+        "time": 481,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -137,29 +137,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 462
+          "wait": 481
         }
       },
       {
-        "_id": "4d0690855a744f173c0920c96adfa26d",
+        "_id": "f0249bf4f98c0cf5ef28022b6d0e22e8",
         "_order": 1,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818291"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822040"
         },
         "response": {
           "bodySize": 932,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 932,
-            "text": "{\"id\":1818291,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.272Z\",\"updated_at\":\"2023-03-09T09:31:12.404Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146516,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516484,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.041Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818291/capabilities/2146516/scenarios/6516484\",\"updated_at\":\"2023-03-09T09:31:12.516Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+            "text": "{\"id\":1822040,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.377Z\",\"updated_at\":\"2023-03-10T08:17:03.538Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151013,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531515,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.954Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822040/capabilities/2151013/scenarios/6531515\",\"updated_at\":\"2023-03-10T08:17:03.590Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
           },
           "cookies": [],
           "headers": [],
@@ -169,335 +169,7 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:13.336Z",
-        "time": 336,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 336
-        }
-      },
-      {
-        "_id": "4d0690855a744f173c0920c96adfa26d",
-        "_order": 2,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818291"
-        },
-        "response": {
-          "bodySize": 932,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 932,
-            "text": "{\"id\":1818291,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.272Z\",\"updated_at\":\"2023-03-09T09:31:12.404Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146516,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516484,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.041Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818291/capabilities/2146516/scenarios/6516484\",\"updated_at\":\"2023-03-09T09:31:12.516Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:14.336Z",
-        "time": 417,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 417
-        }
-      },
-      {
-        "_id": "4d0690855a744f173c0920c96adfa26d",
-        "_order": 3,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818291"
-        },
-        "response": {
-          "bodySize": 932,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 932,
-            "text": "{\"id\":1818291,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.272Z\",\"updated_at\":\"2023-03-09T09:31:12.404Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146516,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516484,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.041Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818291/capabilities/2146516/scenarios/6516484\",\"updated_at\":\"2023-03-09T09:31:12.516Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:15.338Z",
-        "time": 484,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 484
-        }
-      },
-      {
-        "_id": "4d0690855a744f173c0920c96adfa26d",
-        "_order": 4,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818291"
-        },
-        "response": {
-          "bodySize": 932,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 932,
-            "text": "{\"id\":1818291,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.272Z\",\"updated_at\":\"2023-03-09T09:31:12.404Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146516,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516484,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.041Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818291/capabilities/2146516/scenarios/6516484\",\"updated_at\":\"2023-03-09T09:31:12.516Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:16.339Z",
-        "time": 385,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 385
-        }
-      },
-      {
-        "_id": "4d0690855a744f173c0920c96adfa26d",
-        "_order": 5,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818291"
-        },
-        "response": {
-          "bodySize": 932,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 932,
-            "text": "{\"id\":1818291,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.272Z\",\"updated_at\":\"2023-03-09T09:31:12.404Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146516,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516484,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.041Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818291/capabilities/2146516/scenarios/6516484\",\"updated_at\":\"2023-03-09T09:31:12.516Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:17.341Z",
-        "time": 298,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 298
-        }
-      },
-      {
-        "_id": "4d0690855a744f173c0920c96adfa26d",
-        "_order": 6,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818291"
-        },
-        "response": {
-          "bodySize": 932,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 932,
-            "text": "{\"id\":1818291,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.272Z\",\"updated_at\":\"2023-03-09T09:31:12.404Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146516,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516484,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.041Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818291/capabilities/2146516/scenarios/6516484\",\"updated_at\":\"2023-03-09T09:31:12.516Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:18.344Z",
-        "time": 437,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 437
-        }
-      },
-      {
-        "_id": "4d0690855a744f173c0920c96adfa26d",
-        "_order": 7,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818291"
-        },
-        "response": {
-          "bodySize": 932,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 932,
-            "text": "{\"id\":1818291,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.272Z\",\"updated_at\":\"2023-03-09T09:31:12.404Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146516,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516484,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.041Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818291/capabilities/2146516/scenarios/6516484\",\"updated_at\":\"2023-03-09T09:31:12.516Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:19.342Z",
-        "time": 444,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 444
-        }
-      },
-      {
-        "_id": "4d0690855a744f173c0920c96adfa26d",
-        "_order": 8,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818291"
-        },
-        "response": {
-          "bodySize": 932,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 932,
-            "text": "{\"id\":1818291,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.272Z\",\"updated_at\":\"2023-03-09T09:31:12.404Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146516,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516484,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.041Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818291/capabilities/2146516/scenarios/6516484\",\"updated_at\":\"2023-03-09T09:31:12.516Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:20.344Z",
-        "time": 454,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 454
-        }
-      },
-      {
-        "_id": "4d0690855a744f173c0920c96adfa26d",
-        "_order": 9,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818291"
-        },
-        "response": {
-          "bodySize": 932,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 932,
-            "text": "{\"id\":1818291,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.272Z\",\"updated_at\":\"2023-03-09T09:31:12.404Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146516,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516484,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.041Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818291/capabilities/2146516/scenarios/6516484\",\"updated_at\":\"2023-03-09T09:31:12.516Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:21.346Z",
+        "startedDateTime": "2023-03-10T08:17:04.423Z",
         "time": 350,
         "timings": {
           "blocked": -1,
@@ -510,25 +182,353 @@
         }
       },
       {
-        "_id": "4d0690855a744f173c0920c96adfa26d",
+        "_id": "f0249bf4f98c0cf5ef28022b6d0e22e8",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822040"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1822040,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.377Z\",\"updated_at\":\"2023-03-10T08:17:03.538Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151013,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531515,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.954Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822040/capabilities/2151013/scenarios/6531515\",\"updated_at\":\"2023-03-10T08:17:03.590Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:05.424Z",
+        "time": 421,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 421
+        }
+      },
+      {
+        "_id": "f0249bf4f98c0cf5ef28022b6d0e22e8",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822040"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1822040,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.377Z\",\"updated_at\":\"2023-03-10T08:17:03.538Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151013,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531515,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.954Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822040/capabilities/2151013/scenarios/6531515\",\"updated_at\":\"2023-03-10T08:17:03.590Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:06.427Z",
+        "time": 420,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 420
+        }
+      },
+      {
+        "_id": "f0249bf4f98c0cf5ef28022b6d0e22e8",
+        "_order": 4,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822040"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1822040,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.377Z\",\"updated_at\":\"2023-03-10T08:17:03.538Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151013,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531515,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.954Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822040/capabilities/2151013/scenarios/6531515\",\"updated_at\":\"2023-03-10T08:17:03.590Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:07.427Z",
+        "time": 428,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 428
+        }
+      },
+      {
+        "_id": "f0249bf4f98c0cf5ef28022b6d0e22e8",
+        "_order": 5,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822040"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1822040,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.377Z\",\"updated_at\":\"2023-03-10T08:17:03.538Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151013,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531515,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.954Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822040/capabilities/2151013/scenarios/6531515\",\"updated_at\":\"2023-03-10T08:17:03.590Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:08.429Z",
+        "time": 391,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 391
+        }
+      },
+      {
+        "_id": "f0249bf4f98c0cf5ef28022b6d0e22e8",
+        "_order": 6,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822040"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1822040,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.377Z\",\"updated_at\":\"2023-03-10T08:17:03.538Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151013,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531515,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.954Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822040/capabilities/2151013/scenarios/6531515\",\"updated_at\":\"2023-03-10T08:17:03.590Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:09.432Z",
+        "time": 341,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 341
+        }
+      },
+      {
+        "_id": "f0249bf4f98c0cf5ef28022b6d0e22e8",
+        "_order": 7,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822040"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1822040,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.377Z\",\"updated_at\":\"2023-03-10T08:17:03.538Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151013,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531515,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.954Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822040/capabilities/2151013/scenarios/6531515\",\"updated_at\":\"2023-03-10T08:17:03.590Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:10.432Z",
+        "time": 429,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 429
+        }
+      },
+      {
+        "_id": "f0249bf4f98c0cf5ef28022b6d0e22e8",
+        "_order": 8,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822040"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1822040,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.377Z\",\"updated_at\":\"2023-03-10T08:17:03.538Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151013,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531515,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.954Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822040/capabilities/2151013/scenarios/6531515\",\"updated_at\":\"2023-03-10T08:17:03.590Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:11.436Z",
+        "time": 343,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 343
+        }
+      },
+      {
+        "_id": "f0249bf4f98c0cf5ef28022b6d0e22e8",
+        "_order": 9,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822040"
+        },
+        "response": {
+          "bodySize": 932,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 932,
+            "text": "{\"id\":1822040,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.377Z\",\"updated_at\":\"2023-03-10T08:17:03.538Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151013,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531515,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.954Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822040/capabilities/2151013/scenarios/6531515\",\"updated_at\":\"2023-03-10T08:17:03.590Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:12.436Z",
+        "time": 142,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 142
+        }
+      },
+      {
+        "_id": "f0249bf4f98c0cf5ef28022b6d0e22e8",
         "_order": 10,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818291"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822040"
         },
         "response": {
           "bodySize": 932,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 932,
-            "text": "{\"id\":1818291,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.272Z\",\"updated_at\":\"2023-03-09T09:31:12.404Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146516,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516484,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.041Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818291/capabilities/2146516/scenarios/6516484\",\"updated_at\":\"2023-03-09T09:31:12.516Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+            "text": "{\"id\":1822040,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.377Z\",\"updated_at\":\"2023-03-10T08:17:03.538Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151013,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531515,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.954Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822040/capabilities/2151013/scenarios/6531515\",\"updated_at\":\"2023-03-10T08:17:03.590Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
           },
           "cookies": [],
           "headers": [],
@@ -538,8 +538,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:22.346Z",
-        "time": 332,
+        "startedDateTime": "2023-03-10T08:17:13.439Z",
+        "time": 102,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -547,29 +547,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 332
+          "wait": 102
         }
       },
       {
-        "_id": "4d0690855a744f173c0920c96adfa26d",
+        "_id": "f0249bf4f98c0cf5ef28022b6d0e22e8",
         "_order": 11,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818291"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822040"
         },
         "response": {
           "bodySize": 932,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 932,
-            "text": "{\"id\":1818291,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.272Z\",\"updated_at\":\"2023-03-09T09:31:12.404Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146516,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516484,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.041Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818291/capabilities/2146516/scenarios/6516484\",\"updated_at\":\"2023-03-09T09:31:12.516Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+            "text": "{\"id\":1822040,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.377Z\",\"updated_at\":\"2023-03-10T08:17:03.538Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151013,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531515,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.954Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822040/capabilities/2151013/scenarios/6531515\",\"updated_at\":\"2023-03-10T08:17:03.590Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
           },
           "cookies": [],
           "headers": [],
@@ -579,8 +579,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:23.350Z",
-        "time": 165,
+        "startedDateTime": "2023-03-10T08:17:14.443Z",
+        "time": 308,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -588,29 +588,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 165
+          "wait": 308
         }
       },
       {
-        "_id": "4d0690855a744f173c0920c96adfa26d",
+        "_id": "f0249bf4f98c0cf5ef28022b6d0e22e8",
         "_order": 12,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818291"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822040"
         },
         "response": {
-          "bodySize": 932,
+          "bodySize": 974,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 932,
-            "text": "{\"id\":1818291,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:11.272Z\",\"updated_at\":\"2023-03-09T09:31:12.404Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146516,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516484,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:12.041Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818291/capabilities/2146516/scenarios/6516484\",\"updated_at\":\"2023-03-09T09:31:12.516Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+            "size": 974,
+            "text": "{\"id\":1822040,\"status\":\"passed\",\"duration\":9033,\"started_at\":\"2023-03-10T08:17:03.497Z\",\"finished_at\":\"2023-03-10T08:17:12.531Z\",\"created_at\":\"2023-03-10T08:17:02.377Z\",\"updated_at\":\"2023-03-10T08:17:15.090Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151013,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531515,\"test_case_id\":91437,\"status\":\"passed\",\"duration\":5348,\"started_at\":\"2023-03-10T08:17:07.183Z\",\"finished_at\":\"2023-03-10T08:17:12.531Z\",\"created_at\":\"2023-03-10T08:17:02.954Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822040/capabilities/2151013/scenarios/6531515\",\"updated_at\":\"2023-03-10T08:17:14.745Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
           },
           "cookies": [],
           "headers": [],
@@ -620,8 +620,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:24.353Z",
-        "time": 285,
+        "startedDateTime": "2023-03-10T08:17:15.446Z",
+        "time": 367,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -629,48 +629,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 285
-        }
-      },
-      {
-        "_id": "4d0690855a744f173c0920c96adfa26d",
-        "_order": 13,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818291"
-        },
-        "response": {
-          "bodySize": 975,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 975,
-            "text": "{\"id\":1818291,\"status\":\"passed\",\"duration\":10484,\"started_at\":\"2023-03-09T09:31:12.369Z\",\"finished_at\":\"2023-03-09T09:31:22.854Z\",\"created_at\":\"2023-03-09T09:31:11.272Z\",\"updated_at\":\"2023-03-09T09:31:25.677Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146516,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516484,\"test_case_id\":91437,\"status\":\"passed\",\"duration\":6453,\"started_at\":\"2023-03-09T09:31:16.401Z\",\"finished_at\":\"2023-03-09T09:31:22.854Z\",\"created_at\":\"2023-03-09T09:31:12.041Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818291/capabilities/2146516/scenarios/6516484\",\"updated_at\":\"2023-03-09T09:31:25.432Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:25.354Z",
-        "time": 436,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 436
+          "wait": 367
         }
       },
       {
@@ -681,13 +640,13 @@
           "bodySize": 58,
           "cookies": [],
           "headers": [],
-          "headersSize": 342,
+          "headersSize": 343,
           "httpVersion": "HTTP/1.1",
           "method": "DELETE",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"name\":\"autify-cli-a484fe7a-50d0-4805-bd3f-5b489f17c546\"}"
+            "text": "{\"name\":\"autify-cli-96a7357b-44ad-4a50-8ab8-8688303302f4\"}"
           },
           "queryString": [],
           "url": "https://app.autify.com/api/v1/projects/743/autify_connect/access_points"
@@ -707,8 +666,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:26.812Z",
-        "time": 541,
+        "startedDateTime": "2023-03-10T08:17:16.832Z",
+        "time": 440,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -716,7 +675,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 541
+          "wait": 440
         }
       }
     ],

--- a/integration-test/__recordings__/web%20test%20run%20--wait%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Fscenarios%2F91437/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/web%20test%20run%20--wait%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Fscenarios%2F91437/polly-proxy_3343057686/recording.har
@@ -15,7 +15,7 @@
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 271,
+          "headersSize": 272,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
@@ -30,7 +30,7 @@
           },
           "cookies": [
             {
-              "expires": "2043-03-09T09:31:09.000Z",
+              "expires": "2043-03-10T08:17:01.000Z",
               "httpOnly": true,
               "name": "current_project_id",
               "path": "/",
@@ -45,8 +45,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:09.481Z",
-        "time": 234,
+        "startedDateTime": "2023-03-10T08:17:01.195Z",
+        "time": 181,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -54,7 +54,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 234
+          "wait": 181
         }
       },
       {
@@ -65,7 +65,7 @@
           "bodySize": 196,
           "cookies": [],
           "headers": [],
-          "headersSize": 330,
+          "headersSize": 331,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -81,7 +81,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 21,
-            "text": "{\"result_id\":1818289}"
+            "text": "{\"result_id\":1822038}"
           },
           "cookies": [],
           "headers": [],
@@ -91,7 +91,130 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:09.749Z",
+        "startedDateTime": "2023-03-10T08:17:01.421Z",
+        "time": 220,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 220
+        }
+      },
+      {
+        "_id": "9f504ef6551e0e778e5a42b6be77c321",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822038"
+        },
+        "response": {
+          "bodySize": 829,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 829,
+            "text": "{\"id\":1822038,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.605Z\",\"updated_at\":\"2023-03-10T08:17:03.017Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151010,\"capability\":{\"id\":574749,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:01.575Z\",\"updated_at\":\"2023-03-10T08:17:01.575Z\"},\"test_case_results\":[{\"id\":6531512,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.169Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822038/capabilities/2151010/scenarios/6531512\",\"updated_at\":\"2023-03-10T08:17:03.117Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:02.676Z",
+        "time": 470,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 470
+        }
+      },
+      {
+        "_id": "9f504ef6551e0e778e5a42b6be77c321",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822038"
+        },
+        "response": {
+          "bodySize": 829,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 829,
+            "text": "{\"id\":1822038,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.605Z\",\"updated_at\":\"2023-03-10T08:17:03.017Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151010,\"capability\":{\"id\":574749,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:01.575Z\",\"updated_at\":\"2023-03-10T08:17:01.575Z\"},\"test_case_results\":[{\"id\":6531512,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.169Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822038/capabilities/2151010/scenarios/6531512\",\"updated_at\":\"2023-03-10T08:17:03.117Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:03.681Z",
+        "time": 460,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 460
+        }
+      },
+      {
+        "_id": "9f504ef6551e0e778e5a42b6be77c321",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822038"
+        },
+        "response": {
+          "bodySize": 829,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 829,
+            "text": "{\"id\":1822038,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.605Z\",\"updated_at\":\"2023-03-10T08:17:03.017Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151010,\"capability\":{\"id\":574749,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:01.575Z\",\"updated_at\":\"2023-03-10T08:17:01.575Z\"},\"test_case_results\":[{\"id\":6531512,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.169Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822038/capabilities/2151010/scenarios/6531512\",\"updated_at\":\"2023-03-10T08:17:03.117Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:04.683Z",
         "time": 320,
         "timings": {
           "blocked": -1,
@@ -104,148 +227,25 @@
         }
       },
       {
-        "_id": "8fce110993302e07cc4a979a2dc39563",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818289"
-        },
-        "response": {
-          "bodySize": 785,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 785,
-            "text": "{\"id\":1818289,\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.001Z\",\"updated_at\":\"2023-03-09T09:31:10.785Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146512,\"capability\":{\"id\":573873,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:09.971Z\",\"updated_at\":\"2023-03-09T09:31:09.971Z\"},\"test_case_results\":[{\"id\":6516480,\"test_case_id\":91437,\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.764Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818289/capabilities/2146512/scenarios/6516480\",\"updated_at\":\"2023-03-09T09:31:10.816Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:11.103Z",
-        "time": 479,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 479
-        }
-      },
-      {
-        "_id": "8fce110993302e07cc4a979a2dc39563",
-        "_order": 1,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818289"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1818289,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.001Z\",\"updated_at\":\"2023-03-09T09:31:12.349Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146512,\"capability\":{\"id\":573873,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:09.971Z\",\"updated_at\":\"2023-03-09T09:31:09.971Z\"},\"test_case_results\":[{\"id\":6516480,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.764Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818289/capabilities/2146512/scenarios/6516480\",\"updated_at\":\"2023-03-09T09:31:12.431Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:12.107Z",
-        "time": 498,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 498
-        }
-      },
-      {
-        "_id": "8fce110993302e07cc4a979a2dc39563",
-        "_order": 2,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818289"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1818289,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.001Z\",\"updated_at\":\"2023-03-09T09:31:12.349Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146512,\"capability\":{\"id\":573873,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:09.971Z\",\"updated_at\":\"2023-03-09T09:31:09.971Z\"},\"test_case_results\":[{\"id\":6516480,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.764Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818289/capabilities/2146512/scenarios/6516480\",\"updated_at\":\"2023-03-09T09:31:12.431Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:13.108Z",
-        "time": 433,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 433
-        }
-      },
-      {
-        "_id": "8fce110993302e07cc4a979a2dc39563",
+        "_id": "9f504ef6551e0e778e5a42b6be77c321",
         "_order": 3,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818289"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822038"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1818289,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.001Z\",\"updated_at\":\"2023-03-09T09:31:12.349Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146512,\"capability\":{\"id\":573873,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:09.971Z\",\"updated_at\":\"2023-03-09T09:31:09.971Z\"},\"test_case_results\":[{\"id\":6516480,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.764Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818289/capabilities/2146512/scenarios/6516480\",\"updated_at\":\"2023-03-09T09:31:12.431Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1822038,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.605Z\",\"updated_at\":\"2023-03-10T08:17:03.017Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151010,\"capability\":{\"id\":574749,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:01.575Z\",\"updated_at\":\"2023-03-10T08:17:01.575Z\"},\"test_case_results\":[{\"id\":6531512,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.169Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822038/capabilities/2151010/scenarios/6531512\",\"updated_at\":\"2023-03-10T08:17:03.117Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -255,8 +255,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:14.111Z",
-        "time": 350,
+        "startedDateTime": "2023-03-10T08:17:05.685Z",
+        "time": 428,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -264,29 +264,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 350
+          "wait": 428
         }
       },
       {
-        "_id": "8fce110993302e07cc4a979a2dc39563",
+        "_id": "9f504ef6551e0e778e5a42b6be77c321",
         "_order": 4,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818289"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822038"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1818289,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.001Z\",\"updated_at\":\"2023-03-09T09:31:12.349Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146512,\"capability\":{\"id\":573873,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:09.971Z\",\"updated_at\":\"2023-03-09T09:31:09.971Z\"},\"test_case_results\":[{\"id\":6516480,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.764Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818289/capabilities/2146512/scenarios/6516480\",\"updated_at\":\"2023-03-09T09:31:12.431Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1822038,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.605Z\",\"updated_at\":\"2023-03-10T08:17:03.017Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151010,\"capability\":{\"id\":574749,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:01.575Z\",\"updated_at\":\"2023-03-10T08:17:01.575Z\"},\"test_case_results\":[{\"id\":6531512,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.169Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822038/capabilities/2151010/scenarios/6531512\",\"updated_at\":\"2023-03-10T08:17:03.117Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -296,8 +296,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:15.113Z",
-        "time": 407,
+        "startedDateTime": "2023-03-10T08:17:06.685Z",
+        "time": 428,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -305,29 +305,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 407
+          "wait": 428
         }
       },
       {
-        "_id": "8fce110993302e07cc4a979a2dc39563",
+        "_id": "9f504ef6551e0e778e5a42b6be77c321",
         "_order": 5,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818289"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822038"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1818289,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.001Z\",\"updated_at\":\"2023-03-09T09:31:12.349Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146512,\"capability\":{\"id\":573873,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:09.971Z\",\"updated_at\":\"2023-03-09T09:31:09.971Z\"},\"test_case_results\":[{\"id\":6516480,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.764Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818289/capabilities/2146512/scenarios/6516480\",\"updated_at\":\"2023-03-09T09:31:12.431Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1822038,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.605Z\",\"updated_at\":\"2023-03-10T08:17:03.017Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151010,\"capability\":{\"id\":574749,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:01.575Z\",\"updated_at\":\"2023-03-10T08:17:01.575Z\"},\"test_case_results\":[{\"id\":6531512,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.169Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822038/capabilities/2151010/scenarios/6531512\",\"updated_at\":\"2023-03-10T08:17:03.117Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -337,8 +337,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:16.115Z",
-        "time": 410,
+        "startedDateTime": "2023-03-10T08:17:07.689Z",
+        "time": 347,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -346,29 +346,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 410
+          "wait": 347
         }
       },
       {
-        "_id": "8fce110993302e07cc4a979a2dc39563",
+        "_id": "9f504ef6551e0e778e5a42b6be77c321",
         "_order": 6,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818289"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822038"
         },
         "response": {
           "bodySize": 829,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 829,
-            "text": "{\"id\":1818289,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.001Z\",\"updated_at\":\"2023-03-09T09:31:12.349Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146512,\"capability\":{\"id\":573873,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:09.971Z\",\"updated_at\":\"2023-03-09T09:31:09.971Z\"},\"test_case_results\":[{\"id\":6516480,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.764Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818289/capabilities/2146512/scenarios/6516480\",\"updated_at\":\"2023-03-09T09:31:12.431Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1822038,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.605Z\",\"updated_at\":\"2023-03-10T08:17:03.017Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151010,\"capability\":{\"id\":574749,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:01.575Z\",\"updated_at\":\"2023-03-10T08:17:01.575Z\"},\"test_case_results\":[{\"id\":6531512,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.169Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822038/capabilities/2151010/scenarios/6531512\",\"updated_at\":\"2023-03-10T08:17:03.117Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -378,212 +378,7 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:17.116Z",
-        "time": 392,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 392
-        }
-      },
-      {
-        "_id": "8fce110993302e07cc4a979a2dc39563",
-        "_order": 7,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818289"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1818289,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.001Z\",\"updated_at\":\"2023-03-09T09:31:12.349Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146512,\"capability\":{\"id\":573873,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:09.971Z\",\"updated_at\":\"2023-03-09T09:31:09.971Z\"},\"test_case_results\":[{\"id\":6516480,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.764Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818289/capabilities/2146512/scenarios/6516480\",\"updated_at\":\"2023-03-09T09:31:12.431Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:18.119Z",
-        "time": 430,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 430
-        }
-      },
-      {
-        "_id": "8fce110993302e07cc4a979a2dc39563",
-        "_order": 8,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818289"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1818289,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.001Z\",\"updated_at\":\"2023-03-09T09:31:12.349Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146512,\"capability\":{\"id\":573873,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:09.971Z\",\"updated_at\":\"2023-03-09T09:31:09.971Z\"},\"test_case_results\":[{\"id\":6516480,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.764Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818289/capabilities/2146512/scenarios/6516480\",\"updated_at\":\"2023-03-09T09:31:12.431Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:19.119Z",
-        "time": 452,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 452
-        }
-      },
-      {
-        "_id": "8fce110993302e07cc4a979a2dc39563",
-        "_order": 9,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818289"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1818289,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.001Z\",\"updated_at\":\"2023-03-09T09:31:12.349Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146512,\"capability\":{\"id\":573873,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:09.971Z\",\"updated_at\":\"2023-03-09T09:31:09.971Z\"},\"test_case_results\":[{\"id\":6516480,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.764Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818289/capabilities/2146512/scenarios/6516480\",\"updated_at\":\"2023-03-09T09:31:12.431Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:20.122Z",
-        "time": 462,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 462
-        }
-      },
-      {
-        "_id": "8fce110993302e07cc4a979a2dc39563",
-        "_order": 10,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818289"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1818289,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.001Z\",\"updated_at\":\"2023-03-09T09:31:12.349Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146512,\"capability\":{\"id\":573873,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:09.971Z\",\"updated_at\":\"2023-03-09T09:31:09.971Z\"},\"test_case_results\":[{\"id\":6516480,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.764Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818289/capabilities/2146512/scenarios/6516480\",\"updated_at\":\"2023-03-09T09:31:12.431Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:21.123Z",
-        "time": 309,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 309
-        }
-      },
-      {
-        "_id": "8fce110993302e07cc4a979a2dc39563",
-        "_order": 11,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818289"
-        },
-        "response": {
-          "bodySize": 829,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 829,
-            "text": "{\"id\":1818289,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.001Z\",\"updated_at\":\"2023-03-09T09:31:12.349Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146512,\"capability\":{\"id\":573873,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:09.971Z\",\"updated_at\":\"2023-03-09T09:31:09.971Z\"},\"test_case_results\":[{\"id\":6516480,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.764Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818289/capabilities/2146512/scenarios/6516480\",\"updated_at\":\"2023-03-09T09:31:12.431Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:22.127Z",
+        "startedDateTime": "2023-03-10T08:17:08.689Z",
         "time": 447,
         "timings": {
           "blocked": -1,
@@ -596,66 +391,230 @@
         }
       },
       {
-        "_id": "8fce110993302e07cc4a979a2dc39563",
+        "_id": "9f504ef6551e0e778e5a42b6be77c321",
+        "_order": 7,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822038"
+        },
+        "response": {
+          "bodySize": 829,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 829,
+            "text": "{\"id\":1822038,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.605Z\",\"updated_at\":\"2023-03-10T08:17:03.017Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151010,\"capability\":{\"id\":574749,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:01.575Z\",\"updated_at\":\"2023-03-10T08:17:01.575Z\"},\"test_case_results\":[{\"id\":6531512,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.169Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822038/capabilities/2151010/scenarios/6531512\",\"updated_at\":\"2023-03-10T08:17:03.117Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:09.694Z",
+        "time": 364,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 364
+        }
+      },
+      {
+        "_id": "9f504ef6551e0e778e5a42b6be77c321",
+        "_order": 8,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822038"
+        },
+        "response": {
+          "bodySize": 829,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 829,
+            "text": "{\"id\":1822038,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.605Z\",\"updated_at\":\"2023-03-10T08:17:03.017Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151010,\"capability\":{\"id\":574749,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:01.575Z\",\"updated_at\":\"2023-03-10T08:17:01.575Z\"},\"test_case_results\":[{\"id\":6531512,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.169Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822038/capabilities/2151010/scenarios/6531512\",\"updated_at\":\"2023-03-10T08:17:03.117Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:10.697Z",
+        "time": 307,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 307
+        }
+      },
+      {
+        "_id": "9f504ef6551e0e778e5a42b6be77c321",
+        "_order": 9,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822038"
+        },
+        "response": {
+          "bodySize": 829,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 829,
+            "text": "{\"id\":1822038,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.605Z\",\"updated_at\":\"2023-03-10T08:17:03.017Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151010,\"capability\":{\"id\":574749,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:01.575Z\",\"updated_at\":\"2023-03-10T08:17:01.575Z\"},\"test_case_results\":[{\"id\":6531512,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.169Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822038/capabilities/2151010/scenarios/6531512\",\"updated_at\":\"2023-03-10T08:17:03.117Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:11.699Z",
+        "time": 422,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 422
+        }
+      },
+      {
+        "_id": "9f504ef6551e0e778e5a42b6be77c321",
+        "_order": 10,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822038"
+        },
+        "response": {
+          "bodySize": 829,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 829,
+            "text": "{\"id\":1822038,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.605Z\",\"updated_at\":\"2023-03-10T08:17:03.017Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151010,\"capability\":{\"id\":574749,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:01.575Z\",\"updated_at\":\"2023-03-10T08:17:01.575Z\"},\"test_case_results\":[{\"id\":6531512,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.169Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822038/capabilities/2151010/scenarios/6531512\",\"updated_at\":\"2023-03-10T08:17:03.117Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:12.699Z",
+        "time": 272,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 272
+        }
+      },
+      {
+        "_id": "9f504ef6551e0e778e5a42b6be77c321",
+        "_order": 11,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822038"
+        },
+        "response": {
+          "bodySize": 829,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 829,
+            "text": "{\"id\":1822038,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.605Z\",\"updated_at\":\"2023-03-10T08:17:03.017Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151010,\"capability\":{\"id\":574749,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:01.575Z\",\"updated_at\":\"2023-03-10T08:17:01.575Z\"},\"test_case_results\":[{\"id\":6531512,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.169Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822038/capabilities/2151010/scenarios/6531512\",\"updated_at\":\"2023-03-10T08:17:03.117Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:13.703Z",
+        "time": 163,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 163
+        }
+      },
+      {
+        "_id": "9f504ef6551e0e778e5a42b6be77c321",
         "_order": 12,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818289"
-        },
-        "response": {
-          "bodySize": 850,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 850,
-            "text": "{\"id\":1818289,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.001Z\",\"updated_at\":\"2023-03-09T09:31:12.349Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146512,\"capability\":{\"id\":573873,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:09.971Z\",\"updated_at\":\"2023-03-09T09:31:09.971Z\"},\"test_case_results\":[{\"id\":6516480,\"test_case_id\":91437,\"status\":\"passed\",\"duration\":4267,\"started_at\":\"2023-03-09T09:31:16.640Z\",\"finished_at\":\"2023-03-09T09:31:20.907Z\",\"created_at\":\"2023-03-09T09:31:10.764Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818289/capabilities/2146512/scenarios/6516480\",\"updated_at\":\"2023-03-09T09:31:23.215Z\",\"review_needed\":0}]}],\"test_plan\":null}"
-          },
-          "cookies": [],
-          "headers": [],
-          "headersSize": 643,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-03-09T09:31:23.130Z",
-        "time": 164,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 164
-        }
-      },
-      {
-        "_id": "8fce110993302e07cc4a979a2dc39563",
-        "_order": 13,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [],
-          "headersSize": 274,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818289"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822038"
         },
         "response": {
           "bodySize": 871,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 871,
-            "text": "{\"id\":1818289,\"status\":\"passed\",\"duration\":8692,\"started_at\":\"2023-03-09T09:31:12.214Z\",\"finished_at\":\"2023-03-09T09:31:20.907Z\",\"created_at\":\"2023-03-09T09:31:10.001Z\",\"updated_at\":\"2023-03-09T09:31:23.562Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146512,\"capability\":{\"id\":573873,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-09T09:31:09.971Z\",\"updated_at\":\"2023-03-09T09:31:09.971Z\"},\"test_case_results\":[{\"id\":6516480,\"test_case_id\":91437,\"status\":\"passed\",\"duration\":4267,\"started_at\":\"2023-03-09T09:31:16.640Z\",\"finished_at\":\"2023-03-09T09:31:20.907Z\",\"created_at\":\"2023-03-09T09:31:10.764Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818289/capabilities/2146512/scenarios/6516480\",\"updated_at\":\"2023-03-09T09:31:23.215Z\",\"review_needed\":0}]}],\"test_plan\":null}"
+            "text": "{\"id\":1822038,\"status\":\"passed\",\"duration\":8988,\"started_at\":\"2023-03-10T08:17:02.989Z\",\"finished_at\":\"2023-03-10T08:17:11.978Z\",\"created_at\":\"2023-03-10T08:17:01.605Z\",\"updated_at\":\"2023-03-10T08:17:14.652Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151010,\"capability\":{\"id\":574749,\"os\":\"Linux\",\"os_version\":null,\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":null,\"created_at\":\"2023-03-10T08:17:01.575Z\",\"updated_at\":\"2023-03-10T08:17:01.575Z\"},\"test_case_results\":[{\"id\":6531512,\"test_case_id\":91437,\"status\":\"passed\",\"duration\":4889,\"started_at\":\"2023-03-10T08:17:07.089Z\",\"finished_at\":\"2023-03-10T08:17:11.978Z\",\"created_at\":\"2023-03-10T08:17:02.169Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822038/capabilities/2151010/scenarios/6531512\",\"updated_at\":\"2023-03-10T08:17:14.306Z\",\"review_needed\":0}]}],\"test_plan\":null}"
           },
           "cookies": [],
           "headers": [],
@@ -665,8 +624,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:24.130Z",
-        "time": 284,
+        "startedDateTime": "2023-03-10T08:17:14.707Z",
+        "time": 341,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -674,7 +633,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 284
+          "wait": 341
         }
       }
     ],

--- a/integration-test/__recordings__/web%20test%20run%20--wait%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Ftest_plans%2F169408/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/web%20test%20run%20--wait%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Ftest_plans%2F169408/polly-proxy_3343057686/recording.har
@@ -15,7 +15,7 @@
           "bodySize": 2,
           "cookies": [],
           "headers": [],
-          "headersSize": 314,
+          "headersSize": 315,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -31,7 +31,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 79,
-            "text": "{\"data\":{\"id\":\"1818287\",\"type\":\"test_plan_result\",\"attributes\":{\"id\":1818287}}}"
+            "text": "{\"data\":{\"id\":\"1822037\",\"type\":\"test_plan_result\",\"attributes\":{\"id\":1822037}}}"
           },
           "cookies": [],
           "headers": [],
@@ -41,8 +41,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:09.603Z",
-        "time": 215,
+        "startedDateTime": "2023-03-10T08:17:01.349Z",
+        "time": 285,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -50,29 +50,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 215
+          "wait": 285
         }
       },
       {
-        "_id": "e9d1373895ed8fceb9193c5aa8240e7e",
+        "_id": "8127802b4a484033bde2ec3095765139",
         "_order": 0,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818287"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822037"
         },
         "response": {
-          "bodySize": 932,
+          "bodySize": 910,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 932,
-            "text": "{\"id\":1818287,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:09.784Z\",\"updated_at\":\"2023-03-09T09:31:11.199Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146514,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516482,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.824Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818287/capabilities/2146514/scenarios/6516482\",\"updated_at\":\"2023-03-09T09:31:11.117Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+            "size": 910,
+            "text": "{\"id\":1822037,\"status\":\"waiting\",\"duration\":null,\"started_at\":null,\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.593Z\",\"updated_at\":\"2023-03-10T08:17:02.211Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151011,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531513,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.178Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822037/capabilities/2151011/scenarios/6531513\",\"updated_at\":\"2023-03-10T08:17:03.030Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
           },
           "cookies": [],
           "headers": [],
@@ -82,8 +82,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:10.880Z",
-        "time": 398,
+        "startedDateTime": "2023-03-10T08:17:02.680Z",
+        "time": 440,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -91,29 +91,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 398
+          "wait": 440
         }
       },
       {
-        "_id": "e9d1373895ed8fceb9193c5aa8240e7e",
+        "_id": "8127802b4a484033bde2ec3095765139",
         "_order": 1,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818287"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822037"
         },
         "response": {
           "bodySize": 932,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 932,
-            "text": "{\"id\":1818287,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:09.784Z\",\"updated_at\":\"2023-03-09T09:31:11.199Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146514,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516482,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.824Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818287/capabilities/2146514/scenarios/6516482\",\"updated_at\":\"2023-03-09T09:31:11.117Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+            "text": "{\"id\":1822037,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.593Z\",\"updated_at\":\"2023-03-10T08:17:03.099Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151011,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531513,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.178Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822037/capabilities/2151011/scenarios/6531513\",\"updated_at\":\"2023-03-10T08:17:03.030Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
           },
           "cookies": [],
           "headers": [],
@@ -123,8 +123,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:11.883Z",
-        "time": 458,
+        "startedDateTime": "2023-03-10T08:17:03.682Z",
+        "time": 470,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -132,29 +132,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 458
+          "wait": 470
         }
       },
       {
-        "_id": "e9d1373895ed8fceb9193c5aa8240e7e",
+        "_id": "8127802b4a484033bde2ec3095765139",
         "_order": 2,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818287"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822037"
         },
         "response": {
           "bodySize": 932,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 932,
-            "text": "{\"id\":1818287,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:09.784Z\",\"updated_at\":\"2023-03-09T09:31:11.199Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146514,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516482,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.824Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818287/capabilities/2146514/scenarios/6516482\",\"updated_at\":\"2023-03-09T09:31:11.117Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+            "text": "{\"id\":1822037,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.593Z\",\"updated_at\":\"2023-03-10T08:17:03.099Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151011,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531513,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.178Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822037/capabilities/2151011/scenarios/6531513\",\"updated_at\":\"2023-03-10T08:17:03.030Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
           },
           "cookies": [],
           "headers": [],
@@ -164,8 +164,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:12.886Z",
-        "time": 463,
+        "startedDateTime": "2023-03-10T08:17:04.683Z",
+        "time": 333,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -173,29 +173,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 463
+          "wait": 333
         }
       },
       {
-        "_id": "e9d1373895ed8fceb9193c5aa8240e7e",
+        "_id": "8127802b4a484033bde2ec3095765139",
         "_order": 3,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818287"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822037"
         },
         "response": {
           "bodySize": 932,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 932,
-            "text": "{\"id\":1818287,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:09.784Z\",\"updated_at\":\"2023-03-09T09:31:11.199Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146514,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516482,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.824Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818287/capabilities/2146514/scenarios/6516482\",\"updated_at\":\"2023-03-09T09:31:11.117Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+            "text": "{\"id\":1822037,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.593Z\",\"updated_at\":\"2023-03-10T08:17:03.099Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151011,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531513,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.178Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822037/capabilities/2151011/scenarios/6531513\",\"updated_at\":\"2023-03-10T08:17:03.030Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
           },
           "cookies": [],
           "headers": [],
@@ -205,8 +205,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:13.888Z",
-        "time": 323,
+        "startedDateTime": "2023-03-10T08:17:05.687Z",
+        "time": 415,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -214,29 +214,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 323
+          "wait": 415
         }
       },
       {
-        "_id": "e9d1373895ed8fceb9193c5aa8240e7e",
+        "_id": "8127802b4a484033bde2ec3095765139",
         "_order": 4,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818287"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822037"
         },
         "response": {
           "bodySize": 932,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 932,
-            "text": "{\"id\":1818287,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:09.784Z\",\"updated_at\":\"2023-03-09T09:31:11.199Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146514,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516482,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.824Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818287/capabilities/2146514/scenarios/6516482\",\"updated_at\":\"2023-03-09T09:31:11.117Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+            "text": "{\"id\":1822037,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.593Z\",\"updated_at\":\"2023-03-10T08:17:03.099Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151011,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531513,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.178Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822037/capabilities/2151011/scenarios/6531513\",\"updated_at\":\"2023-03-10T08:17:03.030Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
           },
           "cookies": [],
           "headers": [],
@@ -246,8 +246,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:14.888Z",
-        "time": 384,
+        "startedDateTime": "2023-03-10T08:17:06.687Z",
+        "time": 448,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -255,29 +255,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 384
+          "wait": 448
         }
       },
       {
-        "_id": "e9d1373895ed8fceb9193c5aa8240e7e",
+        "_id": "8127802b4a484033bde2ec3095765139",
         "_order": 5,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818287"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822037"
         },
         "response": {
           "bodySize": 932,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 932,
-            "text": "{\"id\":1818287,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:09.784Z\",\"updated_at\":\"2023-03-09T09:31:11.199Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146514,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516482,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.824Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818287/capabilities/2146514/scenarios/6516482\",\"updated_at\":\"2023-03-09T09:31:11.117Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+            "text": "{\"id\":1822037,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.593Z\",\"updated_at\":\"2023-03-10T08:17:03.099Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151011,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531513,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.178Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822037/capabilities/2151011/scenarios/6531513\",\"updated_at\":\"2023-03-10T08:17:03.030Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
           },
           "cookies": [],
           "headers": [],
@@ -287,8 +287,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:15.889Z",
-        "time": 401,
+        "startedDateTime": "2023-03-10T08:17:07.691Z",
+        "time": 348,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -296,29 +296,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 401
+          "wait": 348
         }
       },
       {
-        "_id": "e9d1373895ed8fceb9193c5aa8240e7e",
+        "_id": "8127802b4a484033bde2ec3095765139",
         "_order": 6,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818287"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822037"
         },
         "response": {
           "bodySize": 932,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 932,
-            "text": "{\"id\":1818287,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:09.784Z\",\"updated_at\":\"2023-03-09T09:31:11.199Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146514,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516482,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.824Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818287/capabilities/2146514/scenarios/6516482\",\"updated_at\":\"2023-03-09T09:31:11.117Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+            "text": "{\"id\":1822037,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.593Z\",\"updated_at\":\"2023-03-10T08:17:03.099Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151011,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531513,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.178Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822037/capabilities/2151011/scenarios/6531513\",\"updated_at\":\"2023-03-10T08:17:03.030Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
           },
           "cookies": [],
           "headers": [],
@@ -328,8 +328,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:16.892Z",
-        "time": 568,
+        "startedDateTime": "2023-03-10T08:17:08.690Z",
+        "time": 468,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -337,29 +337,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 568
+          "wait": 468
         }
       },
       {
-        "_id": "e9d1373895ed8fceb9193c5aa8240e7e",
+        "_id": "8127802b4a484033bde2ec3095765139",
         "_order": 7,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818287"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822037"
         },
         "response": {
           "bodySize": 932,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 932,
-            "text": "{\"id\":1818287,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:09.784Z\",\"updated_at\":\"2023-03-09T09:31:11.199Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146514,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516482,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.824Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818287/capabilities/2146514/scenarios/6516482\",\"updated_at\":\"2023-03-09T09:31:11.117Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+            "text": "{\"id\":1822037,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.593Z\",\"updated_at\":\"2023-03-10T08:17:03.099Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151011,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531513,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.178Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822037/capabilities/2151011/scenarios/6531513\",\"updated_at\":\"2023-03-10T08:17:03.030Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
           },
           "cookies": [],
           "headers": [],
@@ -369,8 +369,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:17.896Z",
-        "time": 421,
+        "startedDateTime": "2023-03-10T08:17:09.693Z",
+        "time": 353,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -378,29 +378,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 421
+          "wait": 353
         }
       },
       {
-        "_id": "e9d1373895ed8fceb9193c5aa8240e7e",
+        "_id": "8127802b4a484033bde2ec3095765139",
         "_order": 8,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818287"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822037"
         },
         "response": {
           "bodySize": 932,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 932,
-            "text": "{\"id\":1818287,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:09.784Z\",\"updated_at\":\"2023-03-09T09:31:11.199Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146514,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516482,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.824Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818287/capabilities/2146514/scenarios/6516482\",\"updated_at\":\"2023-03-09T09:31:11.117Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+            "text": "{\"id\":1822037,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.593Z\",\"updated_at\":\"2023-03-10T08:17:03.099Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151011,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531513,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.178Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822037/capabilities/2151011/scenarios/6531513\",\"updated_at\":\"2023-03-10T08:17:03.030Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
           },
           "cookies": [],
           "headers": [],
@@ -410,8 +410,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:18.895Z",
-        "time": 307,
+        "startedDateTime": "2023-03-10T08:17:10.696Z",
+        "time": 321,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -419,29 +419,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 307
+          "wait": 321
         }
       },
       {
-        "_id": "e9d1373895ed8fceb9193c5aa8240e7e",
+        "_id": "8127802b4a484033bde2ec3095765139",
         "_order": 9,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818287"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822037"
         },
         "response": {
           "bodySize": 932,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 932,
-            "text": "{\"id\":1818287,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:09.784Z\",\"updated_at\":\"2023-03-09T09:31:11.199Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146514,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516482,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.824Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818287/capabilities/2146514/scenarios/6516482\",\"updated_at\":\"2023-03-09T09:31:11.117Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+            "text": "{\"id\":1822037,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.593Z\",\"updated_at\":\"2023-03-10T08:17:03.099Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151011,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531513,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.178Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822037/capabilities/2151011/scenarios/6531513\",\"updated_at\":\"2023-03-10T08:17:03.030Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
           },
           "cookies": [],
           "headers": [],
@@ -451,8 +451,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:19.895Z",
-        "time": 377,
+        "startedDateTime": "2023-03-10T08:17:11.701Z",
+        "time": 443,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -460,29 +460,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 377
+          "wait": 443
         }
       },
       {
-        "_id": "e9d1373895ed8fceb9193c5aa8240e7e",
+        "_id": "8127802b4a484033bde2ec3095765139",
         "_order": 10,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818287"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822037"
         },
         "response": {
           "bodySize": 932,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 932,
-            "text": "{\"id\":1818287,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:09.784Z\",\"updated_at\":\"2023-03-09T09:31:11.199Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146514,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516482,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":null,\"created_at\":\"2023-03-09T09:31:10.824Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818287/capabilities/2146514/scenarios/6516482\",\"updated_at\":\"2023-03-09T09:31:11.117Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+            "text": "{\"id\":1822037,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.593Z\",\"updated_at\":\"2023-03-10T08:17:03.099Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151011,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531513,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.178Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822037/capabilities/2151011/scenarios/6531513\",\"updated_at\":\"2023-03-10T08:17:03.030Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
           },
           "cookies": [],
           "headers": [],
@@ -492,8 +492,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:20.899Z",
-        "time": 277,
+        "startedDateTime": "2023-03-10T08:17:12.701Z",
+        "time": 236,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -501,29 +501,29 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 277
+          "wait": 236
         }
       },
       {
-        "_id": "e9d1373895ed8fceb9193c5aa8240e7e",
+        "_id": "8127802b4a484033bde2ec3095765139",
         "_order": 11,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 274,
+          "headersSize": 275,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://app.autify.com/api/v1/projects/743/results/1818287"
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822037"
         },
         "response": {
-          "bodySize": 974,
+          "bodySize": 932,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 974,
-            "text": "{\"id\":1818287,\"status\":\"passed\",\"duration\":8056,\"started_at\":\"2023-03-09T09:31:11.068Z\",\"finished_at\":\"2023-03-09T09:31:19.125Z\",\"created_at\":\"2023-03-09T09:31:09.784Z\",\"updated_at\":\"2023-03-09T09:31:21.721Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2146514,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6516482,\"test_case_id\":91437,\"status\":\"passed\",\"duration\":4728,\"started_at\":\"2023-03-09T09:31:14.397Z\",\"finished_at\":\"2023-03-09T09:31:19.125Z\",\"created_at\":\"2023-03-09T09:31:10.824Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1818287/capabilities/2146514/scenarios/6516482\",\"updated_at\":\"2023-03-09T09:31:21.454Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+            "size": 932,
+            "text": "{\"id\":1822037,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:01.593Z\",\"updated_at\":\"2023-03-10T08:17:03.099Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151011,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531513,\"test_case_id\":91437,\"status\":\"running\",\"duration\":null,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":null,\"created_at\":\"2023-03-10T08:17:02.178Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822037/capabilities/2151011/scenarios/6531513\",\"updated_at\":\"2023-03-10T08:17:03.030Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
           },
           "cookies": [],
           "headers": [],
@@ -533,8 +533,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:21.899Z",
-        "time": 388,
+        "startedDateTime": "2023-03-10T08:17:13.706Z",
+        "time": 149,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -542,7 +542,48 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 388
+          "wait": 149
+        }
+      },
+      {
+        "_id": "8127802b4a484033bde2ec3095765139",
+        "_order": 12,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 275,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/results/1822037"
+        },
+        "response": {
+          "bodySize": 974,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 974,
+            "text": "{\"id\":1822037,\"status\":\"passed\",\"duration\":9548,\"started_at\":\"2023-03-10T08:17:02.945Z\",\"finished_at\":\"2023-03-10T08:17:12.494Z\",\"created_at\":\"2023-03-10T08:17:01.593Z\",\"updated_at\":\"2023-03-10T08:17:14.995Z\",\"review_needed\":false,\"test_plan_capability_results\":[{\"id\":2151011,\"capability\":{\"id\":561030,\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"110.0\",\"device\":\"\",\"created_at\":\"2023-03-02T05:18:15.248Z\",\"updated_at\":\"2023-03-02T05:18:15.248Z\"},\"test_case_results\":[{\"id\":6531513,\"test_case_id\":91437,\"status\":\"passed\",\"duration\":5057,\"started_at\":\"2023-03-10T08:17:07.437Z\",\"finished_at\":\"2023-03-10T08:17:12.494Z\",\"created_at\":\"2023-03-10T08:17:02.178Z\",\"project_url\":\"https://app.autify.com/projects/743/results/1822037/capabilities/2151011/scenarios/6531513\",\"updated_at\":\"2023-03-10T08:17:14.640Z\",\"review_needed\":0}]}],\"test_plan\":{\"id\":169408,\"name\":\"cli test\",\"created_at\":\"2022-05-16T21:16:28.612Z\",\"updated_at\":\"2022-05-16T21:16:28.612Z\"}}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-03-10T08:17:14.708Z",
+        "time": 315,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 315
         }
       }
     ],

--- a/integration-test/__recordings__/web%20test%20run%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Fscenarios%2F91437/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/web%20test%20run%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Fscenarios%2F91437/polly-proxy_3343057686/recording.har
@@ -15,7 +15,7 @@
           "bodySize": 0,
           "cookies": [],
           "headers": [],
-          "headersSize": 271,
+          "headersSize": 272,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
@@ -30,7 +30,7 @@
           },
           "cookies": [
             {
-              "expires": "2043-03-09T09:31:09.000Z",
+              "expires": "2043-03-10T08:17:01.000Z",
               "httpOnly": true,
               "name": "current_project_id",
               "path": "/",
@@ -45,8 +45,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:09.511Z",
-        "time": 188,
+        "startedDateTime": "2023-03-10T08:17:01.445Z",
+        "time": 204,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -54,7 +54,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 188
+          "wait": 204
         }
       },
       {
@@ -65,7 +65,7 @@
           "bodySize": 196,
           "cookies": [],
           "headers": [],
-          "headersSize": 330,
+          "headersSize": 331,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -81,7 +81,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 21,
-            "text": "{\"result_id\":1818288}"
+            "text": "{\"result_id\":1822039}"
           },
           "cookies": [],
           "headers": [],
@@ -91,8 +91,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:09.734Z",
-        "time": 238,
+        "startedDateTime": "2023-03-10T08:17:01.697Z",
+        "time": 309,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -100,7 +100,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 238
+          "wait": 309
         }
       }
     ],

--- a/integration-test/__recordings__/web%20test%20run%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Ftest_plans%2F169408/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/web%20test%20run%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Ftest_plans%2F169408/polly-proxy_3343057686/recording.har
@@ -15,7 +15,7 @@
           "bodySize": 2,
           "cookies": [],
           "headers": [],
-          "headersSize": 314,
+          "headersSize": 315,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -31,7 +31,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 79,
-            "text": "{\"data\":{\"id\":\"1818290\",\"type\":\"test_plan_result\",\"attributes\":{\"id\":1818290}}}"
+            "text": "{\"data\":{\"id\":\"1822036\",\"type\":\"test_plan_result\",\"attributes\":{\"id\":1822036}}}"
           },
           "cookies": [],
           "headers": [],
@@ -41,8 +41,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-03-09T09:31:10.095Z",
-        "time": 232,
+        "startedDateTime": "2023-03-10T08:17:01.050Z",
+        "time": 267,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -50,7 +50,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 232
+          "wait": 267
         }
       }
     ],

--- a/integration-test/__snapshots__/golden/mobileBuildUpload.test.js.snap
+++ b/integration-test/__snapshots__/golden/mobileBuildUpload.test.js.snap
@@ -5,7 +5,7 @@ exports[`autify mobile build upload /path/to/app-debug.apk --workspace-id AAA 1`
   "stderr": "",
   "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
 [HPM] Proxy created: /  -> https://mobile-app.autify.com
-✅ Successfully uploaded android.apk (ID: Eoue6q). See https://mobile-app.autify.com/projects/4yyFEL/builds?os=android&selectedBuildId=Eoue6q&page=1
+✅ Successfully uploaded android.apk (ID: oouMyw). See https://mobile-app.autify.com/projects/4yyFEL/builds?os=android&selectedBuildId=oouMyw&page=1
 [HPM] server close signal received: closing proxy server
 ",
 }

--- a/integration-test/__snapshots__/golden/mobileBuildUploadIos.test.js.snap
+++ b/integration-test/__snapshots__/golden/mobileBuildUploadIos.test.js.snap
@@ -5,7 +5,7 @@ exports[`autify mobile build upload /path/to/ios.app --workspace-id AAA 1`] = `
   "stderr": "",
   "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
 [HPM] Proxy created: /  -> https://mobile-app.autify.com
-✅ Successfully uploaded ios.app (ID: Deu61W). See https://mobile-app.autify.com/projects/4yyFEL/builds?os=ios&selectedBuildId=Deu61W&page=1
+✅ Successfully uploaded ios.app (ID: 7Vumnl). See https://mobile-app.autify.com/projects/4yyFEL/builds?os=ios&selectedBuildId=7Vumnl&page=1
 [HPM] server close signal received: closing proxy server
 ",
 }

--- a/integration-test/__snapshots__/golden/mobileBuildUploadJson.test.js.snap
+++ b/integration-test/__snapshots__/golden/mobileBuildUploadJson.test.js.snap
@@ -6,7 +6,7 @@ exports[`autify mobile build upload /path/to/app-debug.apk --workspace-id AAA --
   "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
 [HPM] Proxy created: /  -> https://mobile-app.autify.com
 {
-  "buildId": "90u6MG"
+  "buildId": "zWu3yj"
 }
 [HPM] server close signal received: closing proxy server
 ",

--- a/integration-test/__snapshots__/golden/mobileTestRun.test.js.snap
+++ b/integration-test/__snapshots__/golden/mobileTestRun.test.js.snap
@@ -5,9 +5,9 @@ exports[`autify mobile test run https://mobile-app.autify.com/projects/AAA/test_
   "stderr": "",
   "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
 [HPM] Proxy created: /  -> https://mobile-app.autify.com
-✅ Successfully started: https://mobile-app.autify.com/projects/4yyFEL/results/gMt0Dy
+✅ Successfully started: https://mobile-app.autify.com/projects/4yyFEL/results/7gtPjM
 To wait for the test result, run the command below:
-💻 $ autify mobile test wait https://mobile-app.autify.com/projects/4yyFEL/results/gMt0Dy
+💻 $ autify mobile test wait https://mobile-app.autify.com/projects/4yyFEL/results/7gtPjM
 [HPM] server close signal received: closing proxy server
 ",
 }

--- a/integration-test/__snapshots__/golden/mobileTestRunAndroid.test.js.snap
+++ b/integration-test/__snapshots__/golden/mobileTestRunAndroid.test.js.snap
@@ -5,10 +5,10 @@ exports[`autify mobile test run https://mobile-app.autify.com/projects/AAA/test_
   "stderr": "",
   "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
 [HPM] Proxy created: /  -> https://mobile-app.autify.com
-✅ Successfully uploaded android.apk (ID: p7uP7j). See https://mobile-app.autify.com/projects/4yyFEL/builds?os=android&selectedBuildId=p7uP7j&page=1
-✅ Successfully started: https://mobile-app.autify.com/projects/4yyFEL/results/xjtv26
+✅ Successfully uploaded android.apk (ID: XYuLXo). See https://mobile-app.autify.com/projects/4yyFEL/builds?os=android&selectedBuildId=XYuLXo&page=1
+✅ Successfully started: https://mobile-app.autify.com/projects/4yyFEL/results/rWtvZX
 To wait for the test result, run the command below:
-💻 $ autify mobile test wait https://mobile-app.autify.com/projects/4yyFEL/results/xjtv26
+💻 $ autify mobile test wait https://mobile-app.autify.com/projects/4yyFEL/results/rWtvZX
 [HPM] server close signal received: closing proxy server
 ",
 }

--- a/integration-test/__snapshots__/golden/mobileTestRunAndroidWait.test.js.snap
+++ b/integration-test/__snapshots__/golden/mobileTestRunAndroidWait.test.js.snap
@@ -5,9 +5,9 @@ exports[`autify mobile test run https://mobile-app.autify.com/projects/AAA/test_
   "stderr": "",
   "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
 [HPM] Proxy created: /  -> https://mobile-app.autify.com
-✅ Successfully uploaded android.apk (ID: PWuEn9). See https://mobile-app.autify.com/projects/4yyFEL/builds?os=android&selectedBuildId=PWuEn9&page=1
-✅ Successfully started: https://mobile-app.autify.com/projects/4yyFEL/results/5OtGoX
-🕐 Waiting for the test result: https://mobile-app.autify.com/projects/4yyFEL/results/5OtGoX
+✅ Successfully uploaded android.apk (ID: 8DubWy). See https://mobile-app.autify.com/projects/4yyFEL/builds?os=android&selectedBuildId=8DubWy&page=1
+✅ Successfully started: https://mobile-app.autify.com/projects/4yyFEL/results/kAtO3k
+🕐 Waiting for the test result: https://mobile-app.autify.com/projects/4yyFEL/results/kAtO3k
 [HH:MM:SS] Waiting... (timeout: 300 s) [started]
 [HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
 [HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
@@ -22,7 +22,7 @@ exports[`autify mobile test run https://mobile-app.autify.com/projects/AAA/test_
 [HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
 [HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
 [HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
@@ -43,7 +43,7 @@ exports[`autify mobile test run https://mobile-app.autify.com/projects/AAA/test_
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 👍 Passed 
 [HH:MM:SS] → TestPlan: 👍 Passed , TestCases: 👍 Passed 
 [HH:MM:SS] Waiting... (timeout: 300 s) [completed]
-✅ Test passed!: https://mobile-app.autify.com/projects/4yyFEL/results/5OtGoX
+✅ Test passed!: https://mobile-app.autify.com/projects/4yyFEL/results/kAtO3k
 [HPM] server close signal received: closing proxy server
 ",
 }

--- a/integration-test/__snapshots__/golden/mobileTestRunIos.test.js.snap
+++ b/integration-test/__snapshots__/golden/mobileTestRunIos.test.js.snap
@@ -5,10 +5,10 @@ exports[`autify mobile test run https://mobile-app.autify.com/projects/AAA/test_
   "stderr": "",
   "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
 [HPM] Proxy created: /  -> https://mobile-app.autify.com
-✅ Successfully uploaded ios.app (ID: mKuXKP). See https://mobile-app.autify.com/projects/4yyFEL/builds?os=ios&selectedBuildId=mKuXKP&page=1
-✅ Successfully started: https://mobile-app.autify.com/projects/4yyFEL/results/3Jt3lj
+✅ Successfully uploaded ios.app (ID: e6u97o). See https://mobile-app.autify.com/projects/4yyFEL/builds?os=ios&selectedBuildId=e6u97o&page=1
+✅ Successfully started: https://mobile-app.autify.com/projects/4yyFEL/results/AAtexl
 To wait for the test result, run the command below:
-💻 $ autify mobile test wait https://mobile-app.autify.com/projects/4yyFEL/results/3Jt3lj
+💻 $ autify mobile test wait https://mobile-app.autify.com/projects/4yyFEL/results/AAtexl
 [HPM] server close signal received: closing proxy server
 ",
 }

--- a/integration-test/__snapshots__/golden/mobileTestRunIosWait.test.js.snap
+++ b/integration-test/__snapshots__/golden/mobileTestRunIosWait.test.js.snap
@@ -5,142 +5,10 @@ exports[`autify mobile test run https://mobile-app.autify.com/projects/AAA/test_
   "stderr": "",
   "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
 [HPM] Proxy created: /  -> https://mobile-app.autify.com
-✅ Successfully uploaded ios.app (ID: VZu42D). See https://mobile-app.autify.com/projects/4yyFEL/builds?os=ios&selectedBuildId=VZu42D&page=1
-✅ Successfully started: https://mobile-app.autify.com/projects/4yyFEL/results/2ytGzb
-🕐 Waiting for the test result: https://mobile-app.autify.com/projects/4yyFEL/results/2ytGzb
+✅ Successfully uploaded ios.app (ID: K4uP0x). See https://mobile-app.autify.com/projects/4yyFEL/builds?os=ios&selectedBuildId=K4uP0x&page=1
+✅ Successfully started: https://mobile-app.autify.com/projects/4yyFEL/results/zwtBWw
+🕐 Waiting for the test result: https://mobile-app.autify.com/projects/4yyFEL/results/zwtBWw
 [HH:MM:SS] Waiting... (timeout: 300 s) [started]
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
@@ -217,7 +85,7 @@ exports[`autify mobile test run https://mobile-app.autify.com/projects/AAA/test_
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 👍 Passed 
 [HH:MM:SS] → TestPlan: 👍 Passed , TestCases: 👍 Passed 
 [HH:MM:SS] Waiting... (timeout: 300 s) [completed]
-✅ Test passed!: https://mobile-app.autify.com/projects/4yyFEL/results/2ytGzb
+✅ Test passed!: https://mobile-app.autify.com/projects/4yyFEL/results/zwtBWw
 [HPM] server close signal received: closing proxy server
 ",
 }

--- a/integration-test/__snapshots__/golden/mobileTestRunWait.test.js.snap
+++ b/integration-test/__snapshots__/golden/mobileTestRunWait.test.js.snap
@@ -5,9 +5,38 @@ exports[`autify mobile test run https://mobile-app.autify.com/projects/AAA/test_
   "stderr": "",
   "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
 [HPM] Proxy created: /  -> https://mobile-app.autify.com
-✅ Successfully started: https://mobile-app.autify.com/projects/4yyFEL/results/X1t1WW
-🕐 Waiting for the test result: https://mobile-app.autify.com/projects/4yyFEL/results/X1t1WW
+✅ Successfully started: https://mobile-app.autify.com/projects/4yyFEL/results/Mlt7VB
+🕐 Waiting for the test result: https://mobile-app.autify.com/projects/4yyFEL/results/Mlt7VB
 [HH:MM:SS] Waiting... (timeout: 300 s) [started]
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
@@ -24,12 +53,11 @@ exports[`autify mobile test run https://mobile-app.autify.com/projects/AAA/test_
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 👍 Passed 
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 👍 Passed 
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 👍 Passed 
 [HH:MM:SS] → TestPlan: 👍 Passed , TestCases: 👍 Passed 
 [HH:MM:SS] Waiting... (timeout: 300 s) [completed]
-✅ Test passed!: https://mobile-app.autify.com/projects/4yyFEL/results/X1t1WW
+✅ Test passed!: https://mobile-app.autify.com/projects/4yyFEL/results/Mlt7VB
 [HPM] server close signal received: closing proxy server
 ",
 }

--- a/integration-test/__snapshots__/golden/webTestRun.test.js.snap
+++ b/integration-test/__snapshots__/golden/webTestRun.test.js.snap
@@ -5,9 +5,9 @@ exports[`autify web test run https://app.autify.com/projects/0000/scenarios/0000
   "stderr": "",
   "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
 [HPM] Proxy created: /  -> https://mobile-app.autify.com
-✅ Successfully started: https://app.autify.com/projects/743/results/1818288 (Capability is Linux Chrome 110.0)
+✅ Successfully started: https://app.autify.com/projects/743/results/1822039 (Capability is Linux Chrome 110.0)
 To wait for the test result, run the command below:
-💻 $ autify web test wait https://app.autify.com/projects/743/results/1818288
+💻 $ autify web test wait https://app.autify.com/projects/743/results/1822039
 [HPM] server close signal received: closing proxy server
 ",
 }

--- a/integration-test/__snapshots__/golden/webTestRunAutifyConnectClient.test.js.snap
+++ b/integration-test/__snapshots__/golden/webTestRunAutifyConnectClient.test.js.snap
@@ -5,16 +5,16 @@ exports[`autify web test run https://app.autify.com/projects/0000/scenarios/0000
   "stderr": "",
   "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
 [HPM] Proxy created: /  -> https://mobile-app.autify.com
-[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Ephemeral Access Point was created: autify-cli-4dc0ee76-5a5c-4d83-922f-31ad256c735c
+[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Ephemeral Access Point was created: autify-cli-8ad2c8cf-df9d-4449-b0f8-352c34426896
 Starting Autify Connect Client...
-[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Starting Autify Connect Client (accessPoint: autify-cli-4dc0ee76-5a5c-4d83-922f-31ad256c735c, debugServerPort: <random>, path: /path/to/autifyconnect, version: Autify Connect version v1.0.2, build 71c6d81)
+[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Starting Autify Connect Client (accessPoint: autify-cli-8ad2c8cf-df9d-4449-b0f8-352c34426896, debugServerPort: <random>, path: /path/to/autifyconnect, version: Autify Connect version v1.0.2, build 71c6d81)
 Waiting until Autify Connect Client is ready...
 [Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	start serving a debug server on http://127.0.0.1:<random>
 [Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	Starting to establish a secure connection with the Autify connect server. Your session ID is "fake".
 [Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	Successfully connected!
 Autify Connect Client is ready!
-✅ Successfully started: https://app.autify.com/projects/743/results/1818292 (Capability is Linux Chrome 110.0)
-🕐 Waiting for the test result: https://app.autify.com/projects/743/results/1818292
+✅ Successfully started: https://app.autify.com/projects/743/results/1822041 (Capability is Linux Chrome 110.0)
+🕐 Waiting for the test result: https://app.autify.com/projects/743/results/1822041
 [HH:MM:SS] Waiting... (timeout: 300 s) [started]
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
@@ -27,15 +27,13 @@ Autify Connect Client is ready!
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 👍 Passed 
 [HH:MM:SS] → TestPlan: 👍 Passed , TestCases: 👍 Passed 
 [HH:MM:SS] Waiting... (timeout: 300 s) [completed]
-✅ Test passed!: https://app.autify.com/projects/743/results/1818292
+✅ Test passed!: https://app.autify.com/projects/743/results/1822041
 Waiting until Autify Connect Client exits...
 [Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	Interrupt received.
 [Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	Shutdown completed.
-[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Ephemeral Access Point was deleted: autify-cli-4dc0ee76-5a5c-4d83-922f-31ad256c735c
+[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Ephemeral Access Point was deleted: autify-cli-8ad2c8cf-df9d-4449-b0f8-352c34426896
 [Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Autify Connect Client exited (code: 0, signal: null)
 Autify Connect Client exited.
 [HPM] server close signal received: closing proxy server

--- a/integration-test/__snapshots__/golden/webTestRunTestPlan.test.js.snap
+++ b/integration-test/__snapshots__/golden/webTestRunTestPlan.test.js.snap
@@ -5,9 +5,9 @@ exports[`autify web test run https://app.autify.com/projects/0000/test_plans/000
   "stderr": "",
   "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
 [HPM] Proxy created: /  -> https://mobile-app.autify.com
-✅ Successfully started: https://app.autify.com/projects/743/results/1818290 (Capability is configured by test plan)
+✅ Successfully started: https://app.autify.com/projects/743/results/1822036 (Capability is configured by test plan)
 To wait for the test result, run the command below:
-💻 $ autify web test wait https://app.autify.com/projects/743/results/1818290
+💻 $ autify web test wait https://app.autify.com/projects/743/results/1822036
 [HPM] server close signal received: closing proxy server
 ",
 }

--- a/integration-test/__snapshots__/golden/webTestRunTestPlanAutifyConnectClient.test.js.snap
+++ b/integration-test/__snapshots__/golden/webTestRunTestPlanAutifyConnectClient.test.js.snap
@@ -5,18 +5,17 @@ exports[`autify web test run https://app.autify.com/projects/0000/test_plans/000
   "stderr": "",
   "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
 [HPM] Proxy created: /  -> https://mobile-app.autify.com
-[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Ephemeral Access Point was created: autify-cli-a484fe7a-50d0-4805-bd3f-5b489f17c546
+[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Ephemeral Access Point was created: autify-cli-96a7357b-44ad-4a50-8ab8-8688303302f4
 Starting Autify Connect Client...
-[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Starting Autify Connect Client (accessPoint: autify-cli-a484fe7a-50d0-4805-bd3f-5b489f17c546, debugServerPort: <random>, path: /path/to/autifyconnect, version: Autify Connect version v1.0.2, build 71c6d81)
+[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Starting Autify Connect Client (accessPoint: autify-cli-96a7357b-44ad-4a50-8ab8-8688303302f4, debugServerPort: <random>, path: /path/to/autifyconnect, version: Autify Connect version v1.0.2, build 71c6d81)
 Waiting until Autify Connect Client is ready...
 [Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	start serving a debug server on http://127.0.0.1:<random>
 [Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	Starting to establish a secure connection with the Autify connect server. Your session ID is "fake".
 [Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	Successfully connected!
 Autify Connect Client is ready!
-✅ Successfully started: https://app.autify.com/projects/743/results/1818291 (Capability is configured by test plan)
-🕐 Waiting for the test result: https://app.autify.com/projects/743/results/1818291
+✅ Successfully started: https://app.autify.com/projects/743/results/1822040 (Capability is configured by test plan)
+🕐 Waiting for the test result: https://app.autify.com/projects/743/results/1822040
 [HH:MM:SS] Waiting... (timeout: 300 s) [started]
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
@@ -31,11 +30,11 @@ Autify Connect Client is ready!
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 👍 Passed , TestCases: 👍 Passed 
 [HH:MM:SS] Waiting... (timeout: 300 s) [completed]
-✅ Test passed!: https://app.autify.com/projects/743/results/1818291
+✅ Test passed!: https://app.autify.com/projects/743/results/1822040
 Waiting until Autify Connect Client exits...
 [Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	Interrupt received.
 [Autify Connect Client]   YYYY-MM-DDTHH:MM:SS.MMMZ	info	Shutdown completed.
-[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Ephemeral Access Point was deleted: autify-cli-a484fe7a-50d0-4805-bd3f-5b489f17c546
+[Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Ephemeral Access Point was deleted: autify-cli-96a7357b-44ad-4a50-8ab8-8688303302f4
 [Autify Connect Manager]  YYYY-MM-DDTHH:MM:SS.MMMZ	info	Autify Connect Client exited (code: 0, signal: null)
 Autify Connect Client exited.
 [HPM] server close signal received: closing proxy server

--- a/integration-test/__snapshots__/golden/webTestRunTestPlanWait.test.js.snap
+++ b/integration-test/__snapshots__/golden/webTestRunTestPlanWait.test.js.snap
@@ -5,9 +5,10 @@ exports[`autify web test run https://app.autify.com/projects/0000/test_plans/000
   "stderr": "",
   "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
 [HPM] Proxy created: /  -> https://mobile-app.autify.com
-✅ Successfully started: https://app.autify.com/projects/743/results/1818287 (Capability is configured by test plan)
-🕐 Waiting for the test result: https://app.autify.com/projects/743/results/1818287
+✅ Successfully started: https://app.autify.com/projects/743/results/1822037 (Capability is configured by test plan)
+🕐 Waiting for the test result: https://app.autify.com/projects/743/results/1822037
 [HH:MM:SS] Waiting... (timeout: 300 s) [started]
+[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
@@ -21,7 +22,7 @@ exports[`autify web test run https://app.autify.com/projects/0000/test_plans/000
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 👍 Passed , TestCases: 👍 Passed 
 [HH:MM:SS] Waiting... (timeout: 300 s) [completed]
-✅ Test passed!: https://app.autify.com/projects/743/results/1818287
+✅ Test passed!: https://app.autify.com/projects/743/results/1822037
 [HPM] server close signal received: closing proxy server
 ",
 }

--- a/integration-test/__snapshots__/golden/webTestRunWait.test.js.snap
+++ b/integration-test/__snapshots__/golden/webTestRunWait.test.js.snap
@@ -5,10 +5,9 @@ exports[`autify web test run https://app.autify.com/projects/0000/scenarios/0000
   "stderr": "",
   "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
 [HPM] Proxy created: /  -> https://mobile-app.autify.com
-✅ Successfully started: https://app.autify.com/projects/743/results/1818289 (Capability is Linux Chrome 110.0)
-🕐 Waiting for the test result: https://app.autify.com/projects/743/results/1818289
+✅ Successfully started: https://app.autify.com/projects/743/results/1822038 (Capability is Linux Chrome 110.0)
+🕐 Waiting for the test result: https://app.autify.com/projects/743/results/1822038
 [HH:MM:SS] Waiting... (timeout: 300 s) [started]
-[HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
@@ -20,10 +19,10 @@ exports[`autify web test run https://app.autify.com/projects/0000/scenarios/0000
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 👍 Passed 
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 👍 Passed , TestCases: 👍 Passed 
 [HH:MM:SS] Waiting... (timeout: 300 s) [completed]
-✅ Test passed!: https://app.autify.com/projects/743/results/1818289
+✅ Test passed!: https://app.autify.com/projects/743/results/1822038
 [HPM] server close signal received: closing proxy server
 ",
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       ],
       "dependencies": {
         "@autifyhq/autify-sdk": "^0.12.0",
-        "@oclif/core": "^1.26.1",
+        "@oclif/core": "^2.6.2",
         "@oclif/errors": "^1.3.6",
         "@oclif/plugin-help": "^5.2.4",
         "@oclif/plugin-not-found": "^2.3.18",
@@ -197,33 +197,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/eslint-parser": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.19.1.tgz",
-      "integrity": "sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==",
-      "dev": true,
-      "dependencies": {
-        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-        "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.11.0",
-        "eslint": "^7.5.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@babel/eslint-parser/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -729,7 +702,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "devOptional": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -741,7 +713,6 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "devOptional": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1242,15 +1213,6 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
-    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
-      "version": "5.1.1-v1",
-      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
-      "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
-      "dev": true,
-      "dependencies": {
-        "eslint-scope": "5.1.1"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1546,20 +1508,19 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.26.1.tgz",
-      "integrity": "sha512-g+OWJcM7JOVI53caTEtq0BB1nPotWctRLUyFODPgvDqXhVR7QED+Qz3LwFAMD8dt7/Ar2ZNq15U3bnpnOv453A==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.6.2.tgz",
+      "integrity": "sha512-roxcBLr4BuoOEDEkMQk4Yy0Tolr39n6i+A63qPLa19vrgxjZZJygh2HpThsn69/UPuEzMq051FnvJ9tNln3Y5g==",
       "dependencies": {
-        "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^3.0.4",
+        "@types/cli-progress": "^3.11.0",
         "ansi-escapes": "^4.3.2",
         "ansi-styles": "^4.3.0",
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
+        "cli-progress": "^3.12.0",
         "debug": "^4.3.4",
-        "ejs": "^3.1.6",
+        "ejs": "^3.1.8",
         "fs-extra": "^9.1.0",
         "get-package-type": "^0.1.0",
         "globby": "^11.1.0",
@@ -1575,8 +1536,10 @@
         "strip-ansi": "^6.0.1",
         "supports-color": "^8.1.1",
         "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
+        "ts-node": "^10.9.1",
+        "tslib": "^2.5.0",
         "widest-line": "^3.1.0",
+        "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
       },
       "engines": {
@@ -1627,11 +1590,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/@oclif/linewrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
-      "integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw=="
-    },
     "node_modules/@oclif/plugin-help": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-5.2.4.tgz",
@@ -1641,44 +1599,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@oclif/plugin-help/node_modules/@oclif/core": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.0.8.tgz",
-      "integrity": "sha512-jt06vEZfpazkR0C8vYuVMKmsxjky52y1B1oFGPnCa6/17qH+PByd5knQP6/QbRoE5OT9RAf4zzpxx2wcihVslw==",
-      "dependencies": {
-        "@types/cli-progress": "^3.11.0",
-        "ansi-escapes": "^4.3.2",
-        "ansi-styles": "^4.3.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.2",
-        "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
-        "debug": "^4.3.4",
-        "ejs": "^3.1.6",
-        "fs-extra": "^9.1.0",
-        "get-package-type": "^0.1.0",
-        "globby": "^11.1.0",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.14.1",
-        "natural-orderby": "^2.0.3",
-        "object-treeify": "^1.1.33",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "supports-color": "^8.1.1",
-        "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
-        "widest-line": "^3.1.0",
-        "wordwrap": "^1.0.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@oclif/plugin-not-found": {
@@ -1693,44 +1613,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@oclif/plugin-not-found/node_modules/@oclif/core": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.0.8.tgz",
-      "integrity": "sha512-jt06vEZfpazkR0C8vYuVMKmsxjky52y1B1oFGPnCa6/17qH+PByd5knQP6/QbRoE5OT9RAf4zzpxx2wcihVslw==",
-      "dependencies": {
-        "@types/cli-progress": "^3.11.0",
-        "ansi-escapes": "^4.3.2",
-        "ansi-styles": "^4.3.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.2",
-        "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
-        "debug": "^4.3.4",
-        "ejs": "^3.1.6",
-        "fs-extra": "^9.1.0",
-        "get-package-type": "^0.1.0",
-        "globby": "^11.1.0",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.14.1",
-        "natural-orderby": "^2.0.3",
-        "object-treeify": "^1.1.33",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "supports-color": "^8.1.1",
-        "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
-        "widest-line": "^3.1.0",
-        "wordwrap": "^1.0.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@oclif/plugin-update": {
@@ -1755,44 +1637,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@oclif/plugin-update/node_modules/@oclif/core": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.0.8.tgz",
-      "integrity": "sha512-jt06vEZfpazkR0C8vYuVMKmsxjky52y1B1oFGPnCa6/17qH+PByd5knQP6/QbRoE5OT9RAf4zzpxx2wcihVslw==",
-      "dependencies": {
-        "@types/cli-progress": "^3.11.0",
-        "ansi-escapes": "^4.3.2",
-        "ansi-styles": "^4.3.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.2",
-        "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
-        "debug": "^4.3.4",
-        "ejs": "^3.1.6",
-        "fs-extra": "^9.1.0",
-        "get-package-type": "^0.1.0",
-        "globby": "^11.1.0",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.14.1",
-        "natural-orderby": "^2.0.3",
-        "object-treeify": "^1.1.33",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "supports-color": "^8.1.1",
-        "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
-        "widest-line": "^3.1.0",
-        "wordwrap": "^1.0.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@oclif/plugin-warn-if-update-available": {
       "version": "2.0.26",
       "resolved": "https://registry.npmjs.org/@oclif/plugin-warn-if-update-available/-/plugin-warn-if-update-available-2.0.26.tgz",
@@ -1810,52 +1654,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@oclif/plugin-warn-if-update-available/node_modules/@oclif/core": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.0.8.tgz",
-      "integrity": "sha512-jt06vEZfpazkR0C8vYuVMKmsxjky52y1B1oFGPnCa6/17qH+PByd5knQP6/QbRoE5OT9RAf4zzpxx2wcihVslw==",
-      "dependencies": {
-        "@types/cli-progress": "^3.11.0",
-        "ansi-escapes": "^4.3.2",
-        "ansi-styles": "^4.3.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.2",
-        "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
-        "debug": "^4.3.4",
-        "ejs": "^3.1.6",
-        "fs-extra": "^9.1.0",
-        "get-package-type": "^0.1.0",
-        "globby": "^11.1.0",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.14.1",
-        "natural-orderby": "^2.0.3",
-        "object-treeify": "^1.1.33",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "supports-color": "^8.1.1",
-        "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
-        "widest-line": "^3.1.0",
-        "wordwrap": "^1.0.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@oclif/screen": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.4.tgz",
-      "integrity": "sha512-IMsTN1dXEXaOSre27j/ywGbBjrzx0FNd1XmuhCWCB9NTPrhWI1Ifbz+YLSEcstfQfocYsrbrIessxXb2oon4lA==",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@oclif/test": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@oclif/test/-/test-2.3.5.tgz",
@@ -1867,45 +1665,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@oclif/test/node_modules/@oclif/core": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.0.8.tgz",
-      "integrity": "sha512-jt06vEZfpazkR0C8vYuVMKmsxjky52y1B1oFGPnCa6/17qH+PByd5knQP6/QbRoE5OT9RAf4zzpxx2wcihVslw==",
-      "dev": true,
-      "dependencies": {
-        "@types/cli-progress": "^3.11.0",
-        "ansi-escapes": "^4.3.2",
-        "ansi-styles": "^4.3.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.2",
-        "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
-        "debug": "^4.3.4",
-        "ejs": "^3.1.6",
-        "fs-extra": "^9.1.0",
-        "get-package-type": "^0.1.0",
-        "globby": "^11.1.0",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.14.1",
-        "natural-orderby": "^2.0.3",
-        "object-treeify": "^1.1.33",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "supports-color": "^8.1.1",
-        "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
-        "widest-line": "^3.1.0",
-        "wordwrap": "^1.0.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -2252,26 +2011,22 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "devOptional": true
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "devOptional": true
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "devOptional": true
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "devOptional": true
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
     },
     "node_modules/@types/archiver": {
       "version": "5.3.1",
@@ -2575,6 +2330,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
     "node_modules/@types/serve-static": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
@@ -2683,30 +2444,32 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
-      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.54.1.tgz",
+      "integrity": "sha512-a2RQAkosH3d3ZIV08s3DcL/mcGc2M/UC528VkPULFxR9VnVPT8pBu0IyBAJJmVsCmhVfwQX1v6q+QGnmSe1bew==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.33.0",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "debug": "^4.3.1",
-        "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
-        "regexpp": "^3.1.0",
-        "semver": "^7.3.5",
+        "@typescript-eslint/scope-manager": "5.54.1",
+        "@typescript-eslint/type-utils": "5.54.1",
+        "@typescript-eslint/utils": "5.54.1",
+        "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "regexpp": "^3.2.0",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^4.0.0",
-        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2714,21 +2477,63 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
-      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
+    "node_modules/@typescript-eslint/parser": {
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.54.1.tgz",
+      "integrity": "sha512-8zaIXJp/nG9Ff9vQNh7TI+C3nA6q6iIsGJ4B4L6MhZ7mHnTMR4YP5vp2xydmFXIy8rpyIVbNAG44871LMt6ujg==",
       "dev": true,
       "dependencies": {
-        "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "@typescript-eslint/scope-manager": "5.54.1",
+        "@typescript-eslint/types": "5.54.1",
+        "@typescript-eslint/typescript-estree": "5.54.1",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.54.1.tgz",
+      "integrity": "sha512-zWKuGliXxvuxyM71UA/EcPxaviw39dB2504LqAmFDjmkpO8qNLHcmzlh6pbHs1h/7YQ9bnsO8CCcYCSA8sykUg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.54.1",
+        "@typescript-eslint/visitor-keys": "5.54.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.54.1.tgz",
+      "integrity": "sha512-WREHsTz0GqVYLIbzIZYbmUUr95DKEKIXZNH57W3s+4bVnuF1TKe2jH8ZNH8rO1CeMY3U4j4UQeqPNkHMiGem3g==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "5.54.1",
+        "@typescript-eslint/utils": "5.54.1",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2736,9 +2541,80 @@
       },
       "peerDependencies": {
         "eslint": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-utils": {
+    "node_modules/@typescript-eslint/types": {
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.54.1.tgz",
+      "integrity": "sha512-G9+1vVazrfAfbtmCapJX8jRo2E4MDXxgm/IMOF4oGh3kq7XuK3JRkOg6y2Qu1VsTRmWETyTkWt1wxy7X7/yLkw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.54.1.tgz",
+      "integrity": "sha512-bjK5t+S6ffHnVwA0qRPTZrxKSaFYocwFIkZx5k7pvWfsB1I57pO/0M0Skatzzw1sCkjJ83AfGTL0oFIFiDX3bg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.54.1",
+        "@typescript-eslint/visitor-keys": "5.54.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.54.1.tgz",
+      "integrity": "sha512-IY5dyQM8XD1zfDe5X8jegX6r2EVU5o/WJnLu/znLPWCBF7KNGC+adacXnt5jEYS9JixDcoccI6CvE4RCjHMzCQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.54.1",
+        "@typescript-eslint/types": "5.54.1",
+        "@typescript-eslint/typescript-estree": "5.54.1",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/eslint-utils": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
       "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
@@ -2756,105 +2632,30 @@
         "eslint": ">=5"
       }
     },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
-      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0"
-      },
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
-      "dev": true,
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0",
-        "debug": "^4.3.1",
-        "globby": "^11.0.3",
-        "is-glob": "^4.0.1",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.1.tgz",
+      "integrity": "sha512-q8iSoHTgwCfgcRJ2l2x+xCbu8nBlRAlsQ33k24Adj8eoVBE0f8dUeI+bAa8F84Mv05UGbAx57g2zrRsYIooqQg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "eslint-visitor-keys": "^2.0.0"
+        "@typescript-eslint/types": "5.54.1",
+        "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@yarnpkg/lockfile": {
@@ -2896,7 +2697,6 @@
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
       "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "devOptional": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2917,7 +2717,6 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "devOptional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3144,8 +2943,7 @@
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "devOptional": true
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -3998,9 +3796,9 @@
       }
     },
     "node_modules/cli-progress": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.2.tgz",
-      "integrity": "sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
       "dependencies": {
         "string-width": "^4.2.3"
       },
@@ -4506,8 +4304,7 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "devOptional": true
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -5240,23 +5037,25 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-36.0.0.tgz",
-      "integrity": "sha512-xxN2vSctGWnDW6aLElm/LKIwcrmk6mdiEcW55Uv5krcrVcIFSWMmEgc/hwpemYfZacKZ5npFERGNz4aThsp1AA==",
+      "version": "41.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-41.0.1.tgz",
+      "integrity": "sha512-gF5vo2dIj0YdNMQ/IMegiBkQdQ22GBFFVpdkJP+0og3w7XD4ypea0xQVRv6iofkLVR2w0phAdikcnU01ybd4Ow==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "ci-info": "^3.2.0",
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "ci-info": "^3.3.0",
         "clean-regexp": "^1.0.0",
-        "eslint-template-visitor": "^2.3.2",
         "eslint-utils": "^3.0.0",
+        "esquery": "^1.4.0",
+        "indent-string": "^4.0.0",
         "is-builtin-module": "^3.1.0",
         "lodash": "^4.17.21",
         "pluralize": "^8.0.0",
         "read-pkg-up": "^7.0.1",
-        "regexp-tree": "^0.1.23",
+        "regexp-tree": "^0.1.24",
         "safe-regex": "^2.1.1",
-        "semver": "^7.3.5"
+        "semver": "^7.3.5",
+        "strip-indent": "^3.0.0"
       },
       "engines": {
         "node": ">=12"
@@ -5265,7 +5064,7 @@
         "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
       },
       "peerDependencies": {
-        "eslint": ">=7.32.0"
+        "eslint": ">=8.8.0"
       }
     },
     "node_modules/eslint-plugin-unicorn/node_modules/eslint-utils": {
@@ -5297,22 +5096,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/eslint-template-visitor": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/eslint-template-visitor/-/eslint-template-visitor-2.3.2.tgz",
-      "integrity": "sha512-3ydhqFpuV7x1M9EK52BPNj6V0Kwu0KKkcIAfpUhwHbR8ocRln/oUHgfxQupY8O1h4Qv/POHDumb/BwwNfxbtnA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.12.16",
-        "@babel/eslint-parser": "^7.12.16",
-        "eslint-visitor-keys": "^2.0.0",
-        "esquery": "^1.3.1",
-        "multimap": "^1.1.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-utils": {
@@ -6099,12 +5882,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
-    "node_modules/functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true
     },
     "node_modules/gauge": {
       "version": "3.0.2",
@@ -8912,8 +8689,7 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "devOptional": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/make-fetch-happen": {
       "version": "9.1.0",
@@ -9110,6 +8886,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -9330,12 +9115,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/multimap": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/multimap/-/multimap-1.1.0.tgz",
-      "integrity": "sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==",
-      "dev": true
-    },
     "node_modules/multimatch": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
@@ -9370,6 +9149,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+    },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true
     },
     "node_modules/natural-orderby": {
       "version": "2.0.3",
@@ -10026,60 +9811,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/oclif/node_modules/@oclif/core": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.0.8.tgz",
-      "integrity": "sha512-jt06vEZfpazkR0C8vYuVMKmsxjky52y1B1oFGPnCa6/17qH+PByd5knQP6/QbRoE5OT9RAf4zzpxx2wcihVslw==",
-      "dev": true,
-      "dependencies": {
-        "@types/cli-progress": "^3.11.0",
-        "ansi-escapes": "^4.3.2",
-        "ansi-styles": "^4.3.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.2",
-        "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
-        "debug": "^4.3.4",
-        "ejs": "^3.1.6",
-        "fs-extra": "^9.1.0",
-        "get-package-type": "^0.1.0",
-        "globby": "^11.1.0",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.14.1",
-        "natural-orderby": "^2.0.3",
-        "object-treeify": "^1.1.33",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "supports-color": "^8.1.1",
-        "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
-        "widest-line": "^3.1.0",
-        "wordwrap": "^1.0.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/oclif/node_modules/@oclif/core/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/oclif/node_modules/fs-extra": {
@@ -12178,6 +11909,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -12496,7 +12239,6 @@
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "devOptional": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12539,7 +12281,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "devOptional": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -12642,7 +12383,6 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12835,8 +12575,7 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "devOptional": true
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
@@ -13457,7 +13196,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "devOptional": true,
       "engines": {
         "node": ">=6"
       }
@@ -13767,25 +13505,6 @@
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
-      }
-    },
-    "@babel/eslint-parser": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.19.1.tgz",
-      "integrity": "sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==",
-      "dev": true,
-      "requires": {
-        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-        "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
         }
       }
     },
@@ -14157,7 +13876,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "devOptional": true,
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -14166,7 +13884,6 @@
           "version": "0.3.9",
           "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
           "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-          "devOptional": true,
           "requires": {
             "@jridgewell/resolve-uri": "^3.0.3",
             "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -14562,15 +14279,6 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
-    "@nicolo-ribaudo/eslint-scope-5-internals": {
-      "version": "5.1.1-v1",
-      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
-      "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
-      "dev": true,
-      "requires": {
-        "eslint-scope": "5.1.1"
-      }
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -14818,20 +14526,19 @@
       }
     },
     "@oclif/core": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.26.1.tgz",
-      "integrity": "sha512-g+OWJcM7JOVI53caTEtq0BB1nPotWctRLUyFODPgvDqXhVR7QED+Qz3LwFAMD8dt7/Ar2ZNq15U3bnpnOv453A==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.6.2.tgz",
+      "integrity": "sha512-roxcBLr4BuoOEDEkMQk4Yy0Tolr39n6i+A63qPLa19vrgxjZZJygh2HpThsn69/UPuEzMq051FnvJ9tNln3Y5g==",
       "requires": {
-        "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^3.0.4",
+        "@types/cli-progress": "^3.11.0",
         "ansi-escapes": "^4.3.2",
         "ansi-styles": "^4.3.0",
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
+        "cli-progress": "^3.12.0",
         "debug": "^4.3.4",
-        "ejs": "^3.1.6",
+        "ejs": "^3.1.8",
         "fs-extra": "^9.1.0",
         "get-package-type": "^0.1.0",
         "globby": "^11.1.0",
@@ -14847,8 +14554,10 @@
         "strip-ansi": "^6.0.1",
         "supports-color": "^8.1.1",
         "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
+        "ts-node": "^10.9.1",
+        "tslib": "^2.5.0",
         "widest-line": "^3.1.0",
+        "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
       }
     },
@@ -14889,54 +14598,12 @@
         }
       }
     },
-    "@oclif/linewrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
-      "integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw=="
-    },
     "@oclif/plugin-help": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-5.2.4.tgz",
       "integrity": "sha512-7fVB/M1cslwHJTmyNGGDYBizi54NHcKCxHAbDSD16EbjosKxFwncRylVC/nsMgKZEufMDKZaVYI2lYRY3GHlSQ==",
       "requires": {
         "@oclif/core": "^2.0.8"
-      },
-      "dependencies": {
-        "@oclif/core": {
-          "version": "2.0.8",
-          "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.0.8.tgz",
-          "integrity": "sha512-jt06vEZfpazkR0C8vYuVMKmsxjky52y1B1oFGPnCa6/17qH+PByd5knQP6/QbRoE5OT9RAf4zzpxx2wcihVslw==",
-          "requires": {
-            "@types/cli-progress": "^3.11.0",
-            "ansi-escapes": "^4.3.2",
-            "ansi-styles": "^4.3.0",
-            "cardinal": "^2.1.1",
-            "chalk": "^4.1.2",
-            "clean-stack": "^3.0.1",
-            "cli-progress": "^3.10.0",
-            "debug": "^4.3.4",
-            "ejs": "^3.1.6",
-            "fs-extra": "^9.1.0",
-            "get-package-type": "^0.1.0",
-            "globby": "^11.1.0",
-            "hyperlinker": "^1.0.0",
-            "indent-string": "^4.0.0",
-            "is-wsl": "^2.2.0",
-            "js-yaml": "^3.14.1",
-            "natural-orderby": "^2.0.3",
-            "object-treeify": "^1.1.33",
-            "password-prompt": "^1.1.2",
-            "semver": "^7.3.7",
-            "string-width": "^4.2.3",
-            "strip-ansi": "^6.0.1",
-            "supports-color": "^8.1.1",
-            "supports-hyperlinks": "^2.2.0",
-            "tslib": "^2.4.1",
-            "widest-line": "^3.1.0",
-            "wordwrap": "^1.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        }
       }
     },
     "@oclif/plugin-not-found": {
@@ -14948,43 +14615,6 @@
         "@oclif/core": "^2.0.3",
         "fast-levenshtein": "^3.0.0",
         "lodash": "^4.17.21"
-      },
-      "dependencies": {
-        "@oclif/core": {
-          "version": "2.0.8",
-          "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.0.8.tgz",
-          "integrity": "sha512-jt06vEZfpazkR0C8vYuVMKmsxjky52y1B1oFGPnCa6/17qH+PByd5knQP6/QbRoE5OT9RAf4zzpxx2wcihVslw==",
-          "requires": {
-            "@types/cli-progress": "^3.11.0",
-            "ansi-escapes": "^4.3.2",
-            "ansi-styles": "^4.3.0",
-            "cardinal": "^2.1.1",
-            "chalk": "^4.1.2",
-            "clean-stack": "^3.0.1",
-            "cli-progress": "^3.10.0",
-            "debug": "^4.3.4",
-            "ejs": "^3.1.6",
-            "fs-extra": "^9.1.0",
-            "get-package-type": "^0.1.0",
-            "globby": "^11.1.0",
-            "hyperlinker": "^1.0.0",
-            "indent-string": "^4.0.0",
-            "is-wsl": "^2.2.0",
-            "js-yaml": "^3.14.1",
-            "natural-orderby": "^2.0.3",
-            "object-treeify": "^1.1.33",
-            "password-prompt": "^1.1.2",
-            "semver": "^7.3.7",
-            "string-width": "^4.2.3",
-            "strip-ansi": "^6.0.1",
-            "supports-color": "^8.1.1",
-            "supports-hyperlinks": "^2.2.0",
-            "tslib": "^2.4.1",
-            "widest-line": "^3.1.0",
-            "wordwrap": "^1.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        }
       }
     },
     "@oclif/plugin-update": {
@@ -15004,43 +14634,6 @@
         "log-chopper": "^1.0.2",
         "semver": "^7.3.8",
         "tar-fs": "^2.1.1"
-      },
-      "dependencies": {
-        "@oclif/core": {
-          "version": "2.0.8",
-          "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.0.8.tgz",
-          "integrity": "sha512-jt06vEZfpazkR0C8vYuVMKmsxjky52y1B1oFGPnCa6/17qH+PByd5knQP6/QbRoE5OT9RAf4zzpxx2wcihVslw==",
-          "requires": {
-            "@types/cli-progress": "^3.11.0",
-            "ansi-escapes": "^4.3.2",
-            "ansi-styles": "^4.3.0",
-            "cardinal": "^2.1.1",
-            "chalk": "^4.1.2",
-            "clean-stack": "^3.0.1",
-            "cli-progress": "^3.10.0",
-            "debug": "^4.3.4",
-            "ejs": "^3.1.6",
-            "fs-extra": "^9.1.0",
-            "get-package-type": "^0.1.0",
-            "globby": "^11.1.0",
-            "hyperlinker": "^1.0.0",
-            "indent-string": "^4.0.0",
-            "is-wsl": "^2.2.0",
-            "js-yaml": "^3.14.1",
-            "natural-orderby": "^2.0.3",
-            "object-treeify": "^1.1.33",
-            "password-prompt": "^1.1.2",
-            "semver": "^7.3.7",
-            "string-width": "^4.2.3",
-            "strip-ansi": "^6.0.1",
-            "supports-color": "^8.1.1",
-            "supports-hyperlinks": "^2.2.0",
-            "tslib": "^2.4.1",
-            "widest-line": "^3.1.0",
-            "wordwrap": "^1.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        }
       }
     },
     "@oclif/plugin-warn-if-update-available": {
@@ -15055,49 +14648,7 @@
         "http-call": "^5.2.2",
         "lodash": "^4.17.21",
         "semver": "^7.3.8"
-      },
-      "dependencies": {
-        "@oclif/core": {
-          "version": "2.0.8",
-          "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.0.8.tgz",
-          "integrity": "sha512-jt06vEZfpazkR0C8vYuVMKmsxjky52y1B1oFGPnCa6/17qH+PByd5knQP6/QbRoE5OT9RAf4zzpxx2wcihVslw==",
-          "requires": {
-            "@types/cli-progress": "^3.11.0",
-            "ansi-escapes": "^4.3.2",
-            "ansi-styles": "^4.3.0",
-            "cardinal": "^2.1.1",
-            "chalk": "^4.1.2",
-            "clean-stack": "^3.0.1",
-            "cli-progress": "^3.10.0",
-            "debug": "^4.3.4",
-            "ejs": "^3.1.6",
-            "fs-extra": "^9.1.0",
-            "get-package-type": "^0.1.0",
-            "globby": "^11.1.0",
-            "hyperlinker": "^1.0.0",
-            "indent-string": "^4.0.0",
-            "is-wsl": "^2.2.0",
-            "js-yaml": "^3.14.1",
-            "natural-orderby": "^2.0.3",
-            "object-treeify": "^1.1.33",
-            "password-prompt": "^1.1.2",
-            "semver": "^7.3.7",
-            "string-width": "^4.2.3",
-            "strip-ansi": "^6.0.1",
-            "supports-color": "^8.1.1",
-            "supports-hyperlinks": "^2.2.0",
-            "tslib": "^2.4.1",
-            "widest-line": "^3.1.0",
-            "wordwrap": "^1.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        }
       }
-    },
-    "@oclif/screen": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.4.tgz",
-      "integrity": "sha512-IMsTN1dXEXaOSre27j/ywGbBjrzx0FNd1XmuhCWCB9NTPrhWI1Ifbz+YLSEcstfQfocYsrbrIessxXb2oon4lA=="
     },
     "@oclif/test": {
       "version": "2.3.5",
@@ -15107,44 +14658,6 @@
       "requires": {
         "@oclif/core": "^2.0.8",
         "fancy-test": "^2.0.12"
-      },
-      "dependencies": {
-        "@oclif/core": {
-          "version": "2.0.8",
-          "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.0.8.tgz",
-          "integrity": "sha512-jt06vEZfpazkR0C8vYuVMKmsxjky52y1B1oFGPnCa6/17qH+PByd5knQP6/QbRoE5OT9RAf4zzpxx2wcihVslw==",
-          "dev": true,
-          "requires": {
-            "@types/cli-progress": "^3.11.0",
-            "ansi-escapes": "^4.3.2",
-            "ansi-styles": "^4.3.0",
-            "cardinal": "^2.1.1",
-            "chalk": "^4.1.2",
-            "clean-stack": "^3.0.1",
-            "cli-progress": "^3.10.0",
-            "debug": "^4.3.4",
-            "ejs": "^3.1.6",
-            "fs-extra": "^9.1.0",
-            "get-package-type": "^0.1.0",
-            "globby": "^11.1.0",
-            "hyperlinker": "^1.0.0",
-            "indent-string": "^4.0.0",
-            "is-wsl": "^2.2.0",
-            "js-yaml": "^3.14.1",
-            "natural-orderby": "^2.0.3",
-            "object-treeify": "^1.1.33",
-            "password-prompt": "^1.1.2",
-            "semver": "^7.3.7",
-            "string-width": "^4.2.3",
-            "strip-ansi": "^6.0.1",
-            "supports-color": "^8.1.1",
-            "supports-hyperlinks": "^2.2.0",
-            "tslib": "^2.4.1",
-            "widest-line": "^3.1.0",
-            "wordwrap": "^1.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        }
       }
     },
     "@octokit/auth-token": {
@@ -15455,26 +14968,22 @@
     "@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "devOptional": true
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
     },
     "@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "devOptional": true
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
     },
     "@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "devOptional": true
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
     },
     "@tsconfig/node16": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "devOptional": true
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
     },
     "@types/archiver": {
       "version": "5.3.1",
@@ -15777,6 +15286,12 @@
         "@types/node": "*"
       }
     },
+    "@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
     "@types/serve-static": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
@@ -15885,33 +15400,92 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA=="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
-      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.54.1.tgz",
+      "integrity": "sha512-a2RQAkosH3d3ZIV08s3DcL/mcGc2M/UC528VkPULFxR9VnVPT8pBu0IyBAJJmVsCmhVfwQX1v6q+QGnmSe1bew==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.33.0",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "debug": "^4.3.1",
-        "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
-        "regexpp": "^3.1.0",
-        "semver": "^7.3.5",
+        "@typescript-eslint/scope-manager": "5.54.1",
+        "@typescript-eslint/type-utils": "5.54.1",
+        "@typescript-eslint/utils": "5.54.1",
+        "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "regexpp": "^3.2.0",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       }
     },
-    "@typescript-eslint/experimental-utils": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
-      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
+    "@typescript-eslint/parser": {
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.54.1.tgz",
+      "integrity": "sha512-8zaIXJp/nG9Ff9vQNh7TI+C3nA6q6iIsGJ4B4L6MhZ7mHnTMR4YP5vp2xydmFXIy8rpyIVbNAG44871LMt6ujg==",
       "dev": true,
       "requires": {
-        "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
+        "@typescript-eslint/scope-manager": "5.54.1",
+        "@typescript-eslint/types": "5.54.1",
+        "@typescript-eslint/typescript-estree": "5.54.1",
+        "debug": "^4.3.4"
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.54.1.tgz",
+      "integrity": "sha512-zWKuGliXxvuxyM71UA/EcPxaviw39dB2504LqAmFDjmkpO8qNLHcmzlh6pbHs1h/7YQ9bnsO8CCcYCSA8sykUg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.54.1",
+        "@typescript-eslint/visitor-keys": "5.54.1"
+      }
+    },
+    "@typescript-eslint/type-utils": {
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.54.1.tgz",
+      "integrity": "sha512-WREHsTz0GqVYLIbzIZYbmUUr95DKEKIXZNH57W3s+4bVnuF1TKe2jH8ZNH8rO1CeMY3U4j4UQeqPNkHMiGem3g==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "5.54.1",
+        "@typescript-eslint/utils": "5.54.1",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.54.1.tgz",
+      "integrity": "sha512-G9+1vVazrfAfbtmCapJX8jRo2E4MDXxgm/IMOF4oGh3kq7XuK3JRkOg6y2Qu1VsTRmWETyTkWt1wxy7X7/yLkw==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.54.1.tgz",
+      "integrity": "sha512-bjK5t+S6ffHnVwA0qRPTZrxKSaFYocwFIkZx5k7pvWfsB1I57pO/0M0Skatzzw1sCkjJ83AfGTL0oFIFiDX3bg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.54.1",
+        "@typescript-eslint/visitor-keys": "5.54.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/utils": {
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.54.1.tgz",
+      "integrity": "sha512-IY5dyQM8XD1zfDe5X8jegX6r2EVU5o/WJnLu/znLPWCBF7KNGC+adacXnt5jEYS9JixDcoccI6CvE4RCjHMzCQ==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.54.1",
+        "@typescript-eslint/types": "5.54.1",
+        "@typescript-eslint/typescript-estree": "5.54.1",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
       },
       "dependencies": {
         "eslint-utils": {
@@ -15925,57 +15499,22 @@
         }
       }
     },
-    "@typescript-eslint/parser": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
-      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "debug": "^4.3.1"
-      }
-    },
-    "@typescript-eslint/scope-manager": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0"
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
-      "dev": true
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0",
-        "debug": "^4.3.1",
-        "globby": "^11.0.3",
-        "is-glob": "^4.0.1",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      }
-    },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.1.tgz",
+      "integrity": "sha512-q8iSoHTgwCfgcRJ2l2x+xCbu8nBlRAlsQ33k24Adj8eoVBE0f8dUeI+bAa8F84Mv05UGbAx57g2zrRsYIooqQg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.33.0",
-        "eslint-visitor-keys": "^2.0.0"
+        "@typescript-eslint/types": "5.54.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+          "dev": true
+        }
       }
     },
     "@yarnpkg/lockfile": {
@@ -16010,8 +15549,7 @@
     "acorn": {
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "devOptional": true
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw=="
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -16023,8 +15561,7 @@
     "acorn-walk": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "devOptional": true
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
     },
     "agent-base": {
       "version": "6.0.2",
@@ -16203,8 +15740,7 @@
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "devOptional": true
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -16837,9 +16373,9 @@
       }
     },
     "cli-progress": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.2.tgz",
-      "integrity": "sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
       "requires": {
         "string-width": "^4.2.3"
       }
@@ -17236,8 +16772,7 @@
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "devOptional": true
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "cross-env": {
       "version": "7.0.3",
@@ -17701,7 +17236,7 @@
         "eslint-config-xo-space": "^0.27.0",
         "eslint-plugin-mocha": "^9.0.0",
         "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-unicorn": "^36.0.0"
+        "eslint-plugin-unicorn": "^41.0.0"
       }
     },
     "eslint-config-oclif-typescript": {
@@ -17710,8 +17245,8 @@
       "integrity": "sha512-TeJKXWBQ3uKMtzgz++UFNWpe1WCx8mfqRuzZy1LirREgRlVv656SkVG4gNZat5rRNIQgfDmTS+YebxK02kfylA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/eslint-plugin": "^4.31.2",
-        "@typescript-eslint/parser": "^4.31.2",
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "@typescript-eslint/parser": "^5.0.0",
         "eslint-config-xo-space": "^0.29.0",
         "eslint-plugin-mocha": "^9.0.0",
         "eslint-plugin-node": "^11.1.0"
@@ -17816,23 +17351,25 @@
       }
     },
     "eslint-plugin-unicorn": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-36.0.0.tgz",
-      "integrity": "sha512-xxN2vSctGWnDW6aLElm/LKIwcrmk6mdiEcW55Uv5krcrVcIFSWMmEgc/hwpemYfZacKZ5npFERGNz4aThsp1AA==",
+      "version": "41.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-41.0.1.tgz",
+      "integrity": "sha512-gF5vo2dIj0YdNMQ/IMegiBkQdQ22GBFFVpdkJP+0og3w7XD4ypea0xQVRv6iofkLVR2w0phAdikcnU01ybd4Ow==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "ci-info": "^3.2.0",
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "ci-info": "^3.3.0",
         "clean-regexp": "^1.0.0",
-        "eslint-template-visitor": "^2.3.2",
         "eslint-utils": "^3.0.0",
+        "esquery": "^1.4.0",
+        "indent-string": "^4.0.0",
         "is-builtin-module": "^3.1.0",
         "lodash": "^4.17.21",
         "pluralize": "^8.0.0",
         "read-pkg-up": "^7.0.1",
-        "regexp-tree": "^0.1.23",
+        "regexp-tree": "^0.1.24",
         "safe-regex": "^2.1.1",
-        "semver": "^7.3.5"
+        "semver": "^7.3.5",
+        "strip-indent": "^3.0.0"
       },
       "dependencies": {
         "eslint-utils": {
@@ -17854,19 +17391,6 @@
       "requires": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
-      }
-    },
-    "eslint-template-visitor": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/eslint-template-visitor/-/eslint-template-visitor-2.3.2.tgz",
-      "integrity": "sha512-3ydhqFpuV7x1M9EK52BPNj6V0Kwu0KKkcIAfpUhwHbR8ocRln/oUHgfxQupY8O1h4Qv/POHDumb/BwwNfxbtnA==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "^7.12.16",
-        "@babel/eslint-parser": "^7.12.16",
-        "eslint-visitor-keys": "^2.0.0",
-        "esquery": "^1.3.1",
-        "multimap": "^1.1.0"
       }
     },
     "eslint-utils": {
@@ -18422,12 +17946,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true
     },
     "gauge": {
       "version": "3.0.2",
@@ -20510,8 +20028,7 @@
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "devOptional": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "make-fetch-happen": {
       "version": "9.1.0",
@@ -20662,6 +20179,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true
+    },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
     },
     "minimatch": {
@@ -20838,12 +20361,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "multimap": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/multimap/-/multimap-1.1.0.tgz",
-      "integrity": "sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==",
-      "dev": true
-    },
     "multimatch": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
@@ -20874,6 +20391,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+    },
+    "natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true
     },
     "natural-orderby": {
       "version": "2.0.3",
@@ -21372,56 +20895,6 @@
         "yosay": "^2.0.2"
       },
       "dependencies": {
-        "@oclif/core": {
-          "version": "2.0.8",
-          "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.0.8.tgz",
-          "integrity": "sha512-jt06vEZfpazkR0C8vYuVMKmsxjky52y1B1oFGPnCa6/17qH+PByd5knQP6/QbRoE5OT9RAf4zzpxx2wcihVslw==",
-          "dev": true,
-          "requires": {
-            "@types/cli-progress": "^3.11.0",
-            "ansi-escapes": "^4.3.2",
-            "ansi-styles": "^4.3.0",
-            "cardinal": "^2.1.1",
-            "chalk": "^4.1.2",
-            "clean-stack": "^3.0.1",
-            "cli-progress": "^3.10.0",
-            "debug": "^4.3.4",
-            "ejs": "^3.1.6",
-            "fs-extra": "^9.1.0",
-            "get-package-type": "^0.1.0",
-            "globby": "^11.1.0",
-            "hyperlinker": "^1.0.0",
-            "indent-string": "^4.0.0",
-            "is-wsl": "^2.2.0",
-            "js-yaml": "^3.14.1",
-            "natural-orderby": "^2.0.3",
-            "object-treeify": "^1.1.33",
-            "password-prompt": "^1.1.2",
-            "semver": "^7.3.7",
-            "string-width": "^4.2.3",
-            "strip-ansi": "^6.0.1",
-            "supports-color": "^8.1.1",
-            "supports-hyperlinks": "^2.2.0",
-            "tslib": "^2.4.1",
-            "widest-line": "^3.1.0",
-            "wordwrap": "^1.0.0",
-            "wrap-ansi": "^7.0.0"
-          },
-          "dependencies": {
-            "fs-extra": {
-              "version": "9.1.0",
-              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-              "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-              "dev": true,
-              "requires": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-              }
-            }
-          }
-        },
         "fs-extra": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -22971,6 +22444,15 @@
       "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
       "dev": true
     },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -23213,7 +22695,6 @@
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "devOptional": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -23233,8 +22714,7 @@
         "diff": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-          "devOptional": true
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
         }
       }
     },
@@ -23313,8 +22793,7 @@
     "typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "devOptional": true
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "unique-filename": {
       "version": "1.1.1",
@@ -23464,8 +22943,7 @@
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "devOptional": true
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "v8-to-istanbul": {
       "version": "9.1.0",
@@ -23940,8 +23418,7 @@
     "yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "devOptional": true
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "@autifyhq/autify-sdk": "^0.12.0",
-    "@oclif/core": "^1.26.1",
+    "@oclif/core": "^2.6.2",
     "@oclif/errors": "^1.3.6",
     "@oclif/plugin-help": "^5.2.4",
     "@oclif/plugin-not-found": "^2.3.18",
@@ -163,6 +163,11 @@
     "prepare": "per-env || true",
     "prepare:development": "husky install",
     "prepare:production": "true"
+  },
+  "overrides": {
+    "eslint-plugin-unicorn": "^41.0.0",
+    "@typescript-eslint/parser": "^5.0.0",
+    "@typescript-eslint/eslint-plugin": "^5.0.0"
   },
   "lint-staged": {
     "**/*.{md,json,yml,js,cjs}": "prettier --write",

--- a/src/autify/mobile/waitTestResult.ts
+++ b/src/autify/mobile/waitTestResult.ts
@@ -39,7 +39,8 @@ const waitUntil = async <T>(
       nonTTYRenderer: "verbose",
     }
   );
-  return (await task.run()).result;
+  const res = await task.run();
+  return res.result;
 };
 
 type Status = Awaited<

--- a/src/autify/web/waitTestResult.ts
+++ b/src/autify/web/waitTestResult.ts
@@ -48,7 +48,8 @@ const waitUntil = async <T>(
       nonTTYRenderer: "verbose",
     }
   );
-  return (await task.run()).result;
+  const res = await task.run();
+  return res.result;
 };
 
 type Status = Awaited<

--- a/src/commands/connect/access-point/create.ts
+++ b/src/commands/connect/access-point/create.ts
@@ -24,7 +24,7 @@ export default class ConnectAccessPointCreate extends Command {
     }),
   };
 
-  static args = [];
+  static args = {};
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(ConnectAccessPointCreate);

--- a/src/commands/connect/client/install.ts
+++ b/src/commands/connect/client/install.ts
@@ -1,4 +1,4 @@
-import { CliUx, Command } from "@oclif/core";
+import { ux, Args, Command } from "@oclif/core";
 import {
   AUTIFY_CONNECT_CLIENT_SUPPORTED_VERSION,
   getConnectClientSourceUrl,
@@ -16,13 +16,12 @@ export default class ConnectClientInstall extends Command {
 
   static flags = {};
 
-  static args = [
-    {
-      name: "version",
+  static args = {
+    version: Args.string({
       description: "Specify the target version of Autify Connect Client.",
       default: AUTIFY_CONNECT_CLIENT_SUPPORTED_VERSION,
-    },
-  ];
+    }),
+  };
 
   public async run(): Promise<void> {
     const { args } = await this.parse(ConnectClientInstall);
@@ -31,7 +30,7 @@ export default class ConnectClientInstall extends Command {
       configDir,
       args.version as string
     );
-    CliUx.ux.action.start(
+    ux.action.start(
       `Installing Autify Connect Client from ${url})`,
       "installing",
       { stdout: true }
@@ -42,7 +41,7 @@ export default class ConnectClientInstall extends Command {
       url,
       expectedVersion
     );
-    CliUx.ux.action.stop();
+    ux.action.stop();
     this.log(
       `Successfully installed Autify Connect Client (path: ${path}, version: ${version})`
     );

--- a/src/commands/mobile/build/upload.ts
+++ b/src/commands/mobile/build/upload.ts
@@ -1,4 +1,4 @@
-import { Command, Flags } from "@oclif/core";
+import { Command, Args, Flags } from "@oclif/core";
 import emoji from "node-emoji";
 import { getBuildDetailUrl } from "../../../autify/mobile/getBuildDetailUrl";
 import { getMobileClient } from "../../../autify/mobile/getMobileClient";
@@ -23,13 +23,12 @@ export default class MobileBuildUpload extends Command {
     }),
   };
 
-  static args = [
-    {
-      name: "build-path",
+  static args = {
+    "build-path": Args.string({
       description: "File path to the iOS app (*.app) or Android app (*.apk).",
       required: true,
-    },
-  ];
+    }),
+  };
 
   public async run(): Promise<{ buildId: string }> {
     const { args, flags } = await this.parse(MobileBuildUpload);

--- a/src/commands/mobile/test/run.ts
+++ b/src/commands/mobile/test/run.ts
@@ -1,4 +1,4 @@
-import { Command, Flags } from "@oclif/core";
+import { Command, Args, Flags } from "@oclif/core";
 import { CLIError } from "@oclif/errors";
 import emoji from "node-emoji";
 import { getMobileClient } from "../../../autify/mobile/getMobileClient";
@@ -48,14 +48,13 @@ export default class MobileTestRun extends Command {
     }),
   };
 
-  static args = [
-    {
-      name: "test-plan-url",
+  static args = {
+    "test-plan-url": Args.string({
       description:
         "Test plan URL e.g. https://mobile-app.autify.com/projects/<ID>/test_plans/<ID>",
       required: true,
-    },
-  ];
+    }),
+  };
 
   public async run(): Promise<void> {
     const { args, flags } = await this.parse(MobileTestRun);
@@ -67,7 +66,8 @@ export default class MobileTestRun extends Command {
     if (buildPath) {
       const uploadArgs = ["--workspace-id", workspaceId, buildPath];
       const uploadCommand = new MobileBuildUpload(uploadArgs, this.config);
-      buildId = (await uploadCommand.run()).buildId;
+      const res = await uploadCommand.run();
+      buildId = res.buildId;
     }
 
     const runTestPlanOnce = async () => {

--- a/src/commands/mobile/test/wait.ts
+++ b/src/commands/mobile/test/wait.ts
@@ -1,4 +1,4 @@
-import { Command, Flags } from "@oclif/core";
+import { Command, Args, Flags } from "@oclif/core";
 import emoji from "node-emoji";
 import { getWaitIntervalSecond } from "../../../autify/getWaitIntervalSecond";
 import { getMobileClient } from "../../../autify/mobile/getMobileClient";
@@ -27,14 +27,13 @@ export default class MobileTestWait extends Command {
     }),
   };
 
-  static args = [
-    {
-      name: "test-result-url",
+  static args = {
+    "test-result-url": Args.string({
       description:
         "Test result URL e.g. https://mobile-app.autify.com/projects/<ID>/results/<ID>",
       required: true,
-    },
-  ];
+    }),
+  };
 
   public async run(): Promise<void> {
     const { args, flags } = await this.parse(MobileTestWait);

--- a/src/commands/web/test/run.ts
+++ b/src/commands/web/test/run.ts
@@ -18,7 +18,6 @@ const parseUrlReplacements = (urlReplacements: string[]) => {
 };
 
 const urlReplacementsToString = (
-  // eslint-disable-next-line camelcase
   urlReplacements: { pattern_url: string; replacement_url: string }[]
 ) => {
   return urlReplacements

--- a/src/commands/web/test/run.ts
+++ b/src/commands/web/test/run.ts
@@ -1,4 +1,4 @@
-import { Command, Flags } from "@oclif/core";
+import { Command, Args, Flags } from "@oclif/core";
 import emoji from "node-emoji";
 import { runTest } from "../../../autify/web/runTest";
 import { getWebTestResultUrl } from "../../../autify/web/getTestResultUrl";
@@ -119,14 +119,13 @@ export default class WebTestRun extends Command {
     }),
   };
 
-  static args = [
-    {
-      name: "scenario-or-test-plan-url",
+  static args = {
+    "scenario-or-test-plan-url": Args.string({
       description:
         "Scenario URL or Test plan URL e.g. https://app.autify.com/projects/<ID>/(scenarios|test_plans)/<ID>",
       required: true,
-    },
-  ];
+    }),
+  };
 
   public async run(): Promise<void> {
     const { args, flags } = await this.parse(WebTestRun);

--- a/src/commands/web/test/wait.ts
+++ b/src/commands/web/test/wait.ts
@@ -1,4 +1,4 @@
-import { Command, Flags } from "@oclif/core";
+import { Command, Args, Flags } from "@oclif/core";
 import emoji from "node-emoji";
 import { parseTestResultUrl } from "../../../autify/web/parseTestResultUrl";
 import { waitTestResult } from "../../../autify/web/waitTestResult";
@@ -27,14 +27,13 @@ export default class WebTestWait extends Command {
     }),
   };
 
-  static args = [
-    {
-      name: "test-result-url",
+  static args = {
+    "test-result-url": Args.string({
       description:
         "Test result URL e.g. https://app.autify.com/projects/<ID>/results/<ID>",
       required: true,
-    },
-  ];
+    }),
+  };
 
   public async run(): Promise<void> {
     const { args, flags } = await this.parse(WebTestWait);


### PR DESCRIPTION
Upgrade oclif/core to v2

1. New golden snapshots taken.

2. Linting failed (and was fixed) as described below.

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Failed to load plugin 'unicorn' declared in '.eslintrc » eslint-config-oclif':
Package subpath './lib/rules/no-warning-comments' is not defined by "exports" in /.../node_modules/eslint/package.json
```

Fix:

https://github.com/oclif/eslint-config-oclif/issues/93

```
  "overrides": {
    "eslint-plugin-unicorn": "^41.0.0",
  }
```

which then produces

```
Bug: (TypeError: Failed to load plugin '@typescript-eslint' declared in '.eslintrc.json':
Class extends value undefined is not a constructor or null)
```

Fix:

https://github.com/eslint/eslint/issues/15149

```
  "overrides": {
    "eslint-plugin-unicorn": "^41.0.0",
    "@typescript-eslint/parser": "^5.0.0",
    "@typescript-eslint/eslint-plugin": "^5.0.0"
  },
```