### PR TITLE
Use space as a delimiter for --url-replacements option

### DIFF
--- a/.github/workflows/github-actions-tests.yml
+++ b/.github/workflows/github-actions-tests.yml
@@ -67,6 +67,28 @@ jobs:
       - run: echo "${{ steps.web-test-run-wait-autify-connect-client.outputs.log }}" | grep "Test passed!"
       - run: echo "${{ steps.web-test-run-wait-autify-connect-client.outputs.result-url }}" | grep -E 'https://app.autify.com/projects/[[:digit:]]+/'
 
+      - id: web-test-run-url-replacements
+        uses: autifyhq/actions-web-test-run@v2
+        with:
+          access-token: token
+          autify-path: autify-with-proxy
+          autify-cli-installer-url: ${{ needs.get.outputs.installer-url }}
+          autify-test-url: https://app.autify.com/projects/0000/scenarios/0000
+          url-replacements: https://example.com https://example.net?foo=bar
+      - run: |
+          echo "${{ steps.web-test-run-url-replacements.outputs.log }}" | grep "Using URL replacements: https://example.com => https://example.net?foo=bar"
+
+      - id: web-test-run-url-replacements-deprecated
+        uses: autifyhq/actions-web-test-run@v2
+        with:
+          access-token: token
+          autify-path: autify-with-proxy
+          autify-cli-installer-url: ${{ needs.get.outputs.installer-url }}
+          autify-test-url: https://app.autify.com/projects/0000/scenarios/0000
+          url-replacements: https://example.com=https://example.net?foo=bar
+      - run: |
+          echo "${{ steps.web-test-run-url-replacements.outputs.log }}" | grep "Using URL replacements: https://example.com => https://example.net?foo=bar"
+
   mobile-test-run:
     needs: [get]
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - run: git config --global core.longpaths true
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -40,6 +41,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
+      - run: git config --global core.longpaths true
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -107,6 +109,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - run: git config --global core.longpaths true
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/README.md
+++ b/README.md
@@ -725,7 +725,7 @@ ARGUMENTS
 
 FLAGS
   -n, --name=<value>                                 [Only for test scenario] Name of the test execution.
-  -r, --url-replacements=<value>...                  URL replacements. Example: http://example.com=http://example.net
+  -r, --url-replacements=<value>...                  URL replacements. Example: "http://example.com http://example.net"
   -t, --timeout=<value>                              [default: 300] Timeout seconds when waiting for the finish of the
                                                      test execution.
   -v, --verbose                                      Verbose output
@@ -769,7 +769,7 @@ EXAMPLES
   With URL replacements:
 
     $ autify web test run https://app.autify.com/projects/0000/scenarios/0000 -r \
-      http://example.com=http://example.net -r http://example.org=http://example.net
+      "http://example.com http://example.net" -r "http://example.org http://example.net"
 
   Run a test with specifying the execution name:
 

--- a/bin/dev
+++ b/bin/dev
@@ -6,12 +6,16 @@ const path = require("path");
 const project = path.join(__dirname, "..", "tsconfig.json");
 
 // In dev mode -> use ts-node and dev plugins
-process.env.NODE_ENV = "development";
+// When `bin/dev` is invoked in integration-test it'll be "test"
+process.env.NODE_ENV ||= "development";
 
 require("ts-node").register({ project });
 
 // In dev mode, always show stack traces
-oclif.settings.debug = true;
+// In test mode, stack traces shouldn't appeared in snapshot
+if (process.env.NODE_ENV === "development") {
+  oclif.settings.debug = true;
+}
 
 // Start the CLI
 oclif

--- a/integration-test/__recordings__/web%20test%20run%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Fscenarios%2F91437%20-r%3D%22https%3A%2F%2Fexample.com%20https%3A%2F%2Fexample.net%3Ffoo%3Dbar%22/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/web%20test%20run%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Fscenarios%2F91437%20-r%3D%22https%3A%2F%2Fexample.com%20https%3A%2F%2Fexample.net%3Ffoo%3Dbar%22/polly-proxy_3343057686/recording.har
@@ -1,0 +1,110 @@
+{
+  "log": {
+    "_recordingName": "polly-proxy",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "73a4b3faba67051f9c497fbd51a01ce4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 269,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/capabilities"
+        },
+        "response": {
+          "bodySize": 14812,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 14812,
+            "text": "[{\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"111.0\",\"device\":null,\"device_type\":null,\"unsupported\":false},{\"os\":\"Windows\",\"os_version\":\"10\",\"browser\":\"Chrome\",\"browser_version\":\"111.0\",\"device\":null,\"device_type\":null,\"unsupported\":false},{\"os\":\"Windows\",\"os_version\":\"10\",\"browser\":\"Edge\",\"browser_version\":\"111.0\",\"device\":null,\"device_type\":null,\"unsupported\":false},{\"os\":\"Windows\",\"os_version\":\"10\",\"browser\":\"Edge Legacy\",\"browser_version\":\"18.0\",\"device\":null,\"device_type\":null,\"unsupported\":true},{\"os\":\"Windows\",\"os_version\":\"10\",\"browser\":\"Firefox\",\"browser_version\":\"111.0\",\"device\":null,\"device_type\":null,\"unsupported\":false},{\"os\":\"Windows\",\"os_version\":\"10\",\"browser\":\"IE\",\"browser_version\":\"11.0\",\"device\":null,\"device_type\":null,\"unsupported\":true},{\"os\":\"Windows Server\",\"os_version\":\"2019\",\"browser\":\"Edge\",\"browser_version\":\"111.0\",\"device\":null,\"device_type\":null,\"unsupported\":false},{\"os\":\"Windows Server\",\"os_version\":\"2019\",\"browser\":\"IE\",\"browser_version\":\"11.0\",\"device\":null,\"device_type\":null,\"unsupported\":true},{\"os\":\"OS X\",\"os_version\":\"Monterey\",\"browser\":\"Chrome\",\"browser_version\":\"111.0\",\"device\":null,\"device_type\":null,\"unsupported\":false},{\"os\":\"OS X\",\"os_version\":\"Monterey\",\"browser\":\"Firefox\",\"browser_version\":\"111.0\",\"device\":null,\"device_type\":null,\"unsupported\":false},{\"os\":\"OS X\",\"os_version\":\"Monterey\",\"browser\":\"Safari\",\"browser_version\":\"15.6\",\"device\":null,\"device_type\":null,\"unsupported\":false},{\"os\":\"OS X\",\"os_version\":\"Monterey\",\"browser\":\"Edge\",\"browser_version\":\"111.0\",\"device\":null,\"device_type\":null,\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"\",\"device\":\"Galaxy S5\",\"device_type\":\"emulator\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"\",\"device\":\"Pixel 2\",\"device_type\":\"emulator\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"\",\"device\":\"Pixel 2 XL\",\"device_type\":\"emulator\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"13.0\",\"device\":\"Pixel 7 Pro\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"13.0\",\"device\":\"Pixel 7\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"13.0\",\"device\":\"Pixel 6 Pro\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"12.0\",\"device\":\"Galaxy S22 Ultra\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"12.0\",\"device\":\"Galaxy S22 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"12.0\",\"device\":\"Galaxy S22\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"12.0\",\"device\":\"Galaxy S21\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"12.0\",\"device\":\"Pixel 6 Pro\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"12.0\",\"device\":\"Pixel 6\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"11.0\",\"device\":\"Galaxy S21 Ultra\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"11.0\",\"device\":\"Galaxy S21\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"11.0\",\"device\":\"Galaxy S21 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Galaxy Note 20 Ultra\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Galaxy Note 20\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Galaxy A51\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Galaxy A11\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Galaxy S10e\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Galaxy S10 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Galaxy S10\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Galaxy Note 10 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Galaxy Note 10\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Galaxy A10\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"8.1\",\"device\":\"Galaxy J7 Prime\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"11.0\",\"device\":\"Pixel 5\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Galaxy S20\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Galaxy S20 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Galaxy S20 Ultra\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Galaxy S9 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"8.1\",\"device\":\"Galaxy Note 9\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"8.0\",\"device\":\"Galaxy S9 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"8.0\",\"device\":\"Galaxy S9\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"7.1\",\"device\":\"Galaxy Note 8\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"7.1\",\"device\":\"Galaxy A8\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"7.0\",\"device\":\"Galaxy S8 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"7.0\",\"device\":\"Galaxy S8\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"6.0\",\"device\":\"Galaxy S7\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"5.0\",\"device\":\"Galaxy S6\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"11.0\",\"device\":\"Pixel 4\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Pixel 4 XL\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Pixel 4\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Pixel 3\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Pixel 3a XL\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Pixel 3a\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Pixel 3 XL\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Pixel 3\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Pixel 2\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"8.0\",\"device\":\"Pixel 2\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"7.1\",\"device\":\"Pixel\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"6.0\",\"device\":\"Nexus 6\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"12.0\",\"device\":\"Galaxy Tab S8\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"11.0\",\"device\":\"Galaxy Tab S7\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Galaxy Tab S7\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Galaxy Tab S6\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Galaxy Tab S5e\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"8.1\",\"device\":\"Galaxy Tab S4\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"\",\"device\":\"iPhone X\",\"device_type\":\"emulator\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"\",\"device\":\"iPhone 6/7/8 Plus\",\"device_type\":\"emulator\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"\",\"device\":\"iPhone 6/7/8\",\"device_type\":\"emulator\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"\",\"device\":\"iPad\",\"device_type\":\"emulator\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"\",\"device\":\"iPad Pro\",\"device_type\":\"emulator\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"16\",\"device\":\"iPhone 14 Pro Max\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"16\",\"device\":\"iPhone 14 Pro\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"16\",\"device\":\"iPhone 14 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"16\",\"device\":\"iPhone 14\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"16\",\"device\":\"iPhone 12 Mini\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone 13 Pro Max\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone 13 Pro\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone 13 Mini\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone 13\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone XS\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone 11 Pro\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone 11\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone XR\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone 8\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPhone XS\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPhone 12 Pro Max\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPhone 12 Pro\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPhone 12 Mini\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPhone 12\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPhone 11 Pro Max\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPhone 8 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPhone 11\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPhone XS\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPhone 11 Pro Max\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPhone 11 Pro\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPhone 11\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPhone XS\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPhone XS Max\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPhone XR\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPhone X\",\"device_type\":\"mobile\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPhone 8\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPhone 8\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPhone 8\",\"device_type\":\"mobile\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPhone 8 Plus\",\"device_type\":\"mobile\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPhone 7\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPhone 6S\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPhone 6S\",\"device_type\":\"mobile\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPhone 6S Plus\",\"device_type\":\"mobile\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPhone 6\",\"device_type\":\"mobile\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone SE 2022\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPhone SE 2020\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPhone SE\",\"device_type\":\"mobile\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"16\",\"device\":\"iPad 10th\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"16\",\"device\":\"iPad Pro 12.9 2022\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"16\",\"device\":\"iPad Pro 11 2022\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPad 9th\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPad Mini 2021\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPad Air 4\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPad Pro 12.9 2021\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPad Pro 12.9 2020\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPad Pro 11 2021\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPad Pro 12.9 2018\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPad 8th\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPad Mini 2019\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPad Air 2019\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPad Pro 12.9 2020\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPad Pro 12.9 2018\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPad Pro 12.9 2018\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPad Pro 11 2020\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPad Pro 11 2018\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPad Pro 9.7 2016\",\"device_type\":\"tablet\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPad Pro 12.9 2017\",\"device_type\":\"tablet\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPad Air 2019\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPad Mini 2019\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPad Mini 4\",\"device_type\":\"tablet\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPad 7th\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPad 6th\",\"device_type\":\"tablet\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPad 5th\",\"device_type\":\"tablet\",\"unsupported\":true}]"
+          },
+          "cookies": [
+            {
+              "expires": "2043-04-04T05:22:05.000Z",
+              "httpOnly": true,
+              "name": "current_project_id",
+              "path": "/",
+              "secure": true,
+              "value": "743"
+            }
+          ],
+          "headers": [],
+          "headersSize": 744,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-04-04T05:22:07.270Z",
+        "time": 156,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 156
+        }
+      },
+      {
+        "_id": "8f4240857864d096884bd3dc9f919a4f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 281,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 328,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"capabilities\":[{\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"111.0\",\"device\":null,\"device_type\":null,\"unsupported\":false}],\"scenarios\":[{\"id\":91437}],\"url_replacements\":[{\"pattern_url\":\"https://example.com\",\"replacement_url\":\"https://example.net?foo=bar\"}]}"
+          },
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/execute_scenarios"
+        },
+        "response": {
+          "bodySize": 21,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 21,
+            "text": "{\"result_id\":1911916}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-04-04T05:22:07.474Z",
+        "time": 165,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 165
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/integration-test/__recordings__/web%20test%20run%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Fscenarios%2F91437%20-r%3D%22https%3A%2F%2Fexample.com%3Dhttps%3A%2F%2Fexample.net%3Ffoo%3Dbar%22/polly-proxy_3343057686/recording.har
+++ b/integration-test/__recordings__/web%20test%20run%20https%3A%2F%2Fapp.autify.com%2Fprojects%2F743%2Fscenarios%2F91437%20-r%3D%22https%3A%2F%2Fexample.com%3Dhttps%3A%2F%2Fexample.net%3Ffoo%3Dbar%22/polly-proxy_3343057686/recording.har
@@ -1,0 +1,110 @@
+{
+  "log": {
+    "_recordingName": "polly-proxy",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "73a4b3faba67051f9c497fbd51a01ce4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 269,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/capabilities"
+        },
+        "response": {
+          "bodySize": 14812,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 14812,
+            "text": "[{\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"111.0\",\"device\":null,\"device_type\":null,\"unsupported\":false},{\"os\":\"Windows\",\"os_version\":\"10\",\"browser\":\"Chrome\",\"browser_version\":\"111.0\",\"device\":null,\"device_type\":null,\"unsupported\":false},{\"os\":\"Windows\",\"os_version\":\"10\",\"browser\":\"Edge\",\"browser_version\":\"111.0\",\"device\":null,\"device_type\":null,\"unsupported\":false},{\"os\":\"Windows\",\"os_version\":\"10\",\"browser\":\"Edge Legacy\",\"browser_version\":\"18.0\",\"device\":null,\"device_type\":null,\"unsupported\":true},{\"os\":\"Windows\",\"os_version\":\"10\",\"browser\":\"Firefox\",\"browser_version\":\"111.0\",\"device\":null,\"device_type\":null,\"unsupported\":false},{\"os\":\"Windows\",\"os_version\":\"10\",\"browser\":\"IE\",\"browser_version\":\"11.0\",\"device\":null,\"device_type\":null,\"unsupported\":true},{\"os\":\"Windows Server\",\"os_version\":\"2019\",\"browser\":\"Edge\",\"browser_version\":\"111.0\",\"device\":null,\"device_type\":null,\"unsupported\":false},{\"os\":\"Windows Server\",\"os_version\":\"2019\",\"browser\":\"IE\",\"browser_version\":\"11.0\",\"device\":null,\"device_type\":null,\"unsupported\":true},{\"os\":\"OS X\",\"os_version\":\"Monterey\",\"browser\":\"Chrome\",\"browser_version\":\"111.0\",\"device\":null,\"device_type\":null,\"unsupported\":false},{\"os\":\"OS X\",\"os_version\":\"Monterey\",\"browser\":\"Firefox\",\"browser_version\":\"111.0\",\"device\":null,\"device_type\":null,\"unsupported\":false},{\"os\":\"OS X\",\"os_version\":\"Monterey\",\"browser\":\"Safari\",\"browser_version\":\"15.6\",\"device\":null,\"device_type\":null,\"unsupported\":false},{\"os\":\"OS X\",\"os_version\":\"Monterey\",\"browser\":\"Edge\",\"browser_version\":\"111.0\",\"device\":null,\"device_type\":null,\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"\",\"device\":\"Galaxy S5\",\"device_type\":\"emulator\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"\",\"device\":\"Pixel 2\",\"device_type\":\"emulator\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"\",\"device\":\"Pixel 2 XL\",\"device_type\":\"emulator\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"13.0\",\"device\":\"Pixel 7 Pro\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"13.0\",\"device\":\"Pixel 7\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"13.0\",\"device\":\"Pixel 6 Pro\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"12.0\",\"device\":\"Galaxy S22 Ultra\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"12.0\",\"device\":\"Galaxy S22 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"12.0\",\"device\":\"Galaxy S22\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"12.0\",\"device\":\"Galaxy S21\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"12.0\",\"device\":\"Pixel 6 Pro\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"12.0\",\"device\":\"Pixel 6\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"12.0\",\"device\":\"Pixel 5\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"11.0\",\"device\":\"Galaxy S21 Ultra\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"11.0\",\"device\":\"Galaxy S21\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"11.0\",\"device\":\"Galaxy S21 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Galaxy Note 20 Ultra\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Galaxy Note 20\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Galaxy A51\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Galaxy A11\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Galaxy S10e\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Galaxy S10 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Galaxy S10\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Galaxy Note 10 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Galaxy Note 10\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Galaxy A10\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"8.1\",\"device\":\"Galaxy J7 Prime\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"11.0\",\"device\":\"Pixel 5\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Galaxy S20\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Galaxy S20 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Galaxy S20 Ultra\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Galaxy S9 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"8.1\",\"device\":\"Galaxy Note 9\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"8.0\",\"device\":\"Galaxy S9 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"8.0\",\"device\":\"Galaxy S9\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"7.1\",\"device\":\"Galaxy Note 8\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"7.1\",\"device\":\"Galaxy A8\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"7.0\",\"device\":\"Galaxy S8 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"7.0\",\"device\":\"Galaxy S8\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"6.0\",\"device\":\"Galaxy S7\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"5.0\",\"device\":\"Galaxy S6\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"11.0\",\"device\":\"Pixel 4\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Pixel 4 XL\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Pixel 4\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Pixel 3\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Pixel 3a XL\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Pixel 3a\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Pixel 3 XL\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Pixel 3\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Pixel 2\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"8.0\",\"device\":\"Pixel 2\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"7.1\",\"device\":\"Pixel\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"6.0\",\"device\":\"Nexus 6\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"12.0\",\"device\":\"Galaxy Tab S8\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"11.0\",\"device\":\"Galaxy Tab S7\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"10.0\",\"device\":\"Galaxy Tab S7\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Galaxy Tab S6\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"9.0\",\"device\":\"Galaxy Tab S5e\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"Android\",\"os_version\":\"8.1\",\"device\":\"Galaxy Tab S4\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"\",\"device\":\"iPhone X\",\"device_type\":\"emulator\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"\",\"device\":\"iPhone 6/7/8 Plus\",\"device_type\":\"emulator\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"\",\"device\":\"iPhone 6/7/8\",\"device_type\":\"emulator\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"\",\"device\":\"iPad\",\"device_type\":\"emulator\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"\",\"device\":\"iPad Pro\",\"device_type\":\"emulator\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"16\",\"device\":\"iPhone 14 Pro Max\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"16\",\"device\":\"iPhone 14 Pro\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"16\",\"device\":\"iPhone 14 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"16\",\"device\":\"iPhone 14\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"16\",\"device\":\"iPhone 12 Mini\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone 13 Pro Max\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone 13 Pro\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone 13 Mini\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone 13\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone XS\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone 11 Pro\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone 11\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone XR\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone 8\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPhone XS\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPhone 12 Pro Max\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPhone 12 Pro\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPhone 12 Mini\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPhone 12\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPhone 11 Pro Max\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPhone 8 Plus\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPhone 11\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPhone XS\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPhone 11 Pro Max\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPhone 11 Pro\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPhone 11\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPhone XS\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPhone XS Max\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPhone XR\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPhone X\",\"device_type\":\"mobile\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPhone 8\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPhone 8\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPhone 8\",\"device_type\":\"mobile\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPhone 8 Plus\",\"device_type\":\"mobile\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPhone 7\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPhone 6S\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPhone 6S\",\"device_type\":\"mobile\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPhone 6S Plus\",\"device_type\":\"mobile\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPhone 6\",\"device_type\":\"mobile\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPhone SE 2022\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPhone SE 2020\",\"device_type\":\"mobile\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPhone SE\",\"device_type\":\"mobile\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"16\",\"device\":\"iPad 10th\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"16\",\"device\":\"iPad Pro 12.9 2022\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"16\",\"device\":\"iPad Pro 11 2022\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPad 9th\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPad Mini 2021\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPad Air 4\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPad Pro 12.9 2021\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPad Pro 12.9 2020\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPad Pro 11 2021\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"15\",\"device\":\"iPad Pro 12.9 2018\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"14\",\"device\":\"iPad 8th\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPad Mini 2019\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPad Air 2019\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPad Pro 12.9 2020\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPad Pro 12.9 2018\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPad Pro 12.9 2018\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPad Pro 11 2020\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPad Pro 11 2018\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPad Pro 9.7 2016\",\"device_type\":\"tablet\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPad Pro 12.9 2017\",\"device_type\":\"tablet\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPad Air 2019\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"12\",\"device\":\"iPad Mini 2019\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPad Mini 4\",\"device_type\":\"tablet\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"13\",\"device\":\"iPad 7th\",\"device_type\":\"tablet\",\"unsupported\":false},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPad 6th\",\"device_type\":\"tablet\",\"unsupported\":true},{\"os\":\"iOS\",\"os_version\":\"11\",\"device\":\"iPad 5th\",\"device_type\":\"tablet\",\"unsupported\":true}]"
+          },
+          "cookies": [
+            {
+              "expires": "2043-04-04T05:22:05.000Z",
+              "httpOnly": true,
+              "name": "current_project_id",
+              "path": "/",
+              "secure": true,
+              "value": "743"
+            }
+          ],
+          "headers": [],
+          "headersSize": 744,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-04-04T05:22:07.360Z",
+        "time": 102,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 102
+        }
+      },
+      {
+        "_id": "8f4240857864d096884bd3dc9f919a4f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 281,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 328,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"capabilities\":[{\"os\":\"Linux\",\"os_version\":\"\",\"browser\":\"Chrome\",\"browser_version\":\"111.0\",\"device\":null,\"device_type\":null,\"unsupported\":false}],\"scenarios\":[{\"id\":91437}],\"url_replacements\":[{\"pattern_url\":\"https://example.com\",\"replacement_url\":\"https://example.net?foo=bar\"}]}"
+          },
+          "queryString": [],
+          "url": "https://app.autify.com/api/v1/projects/743/execute_scenarios"
+        },
+        "response": {
+          "bodySize": 21,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 21,
+            "text": "{\"result_id\":1911917}"
+          },
+          "cookies": [],
+          "headers": [],
+          "headersSize": 643,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-04-04T05:22:07.529Z",
+        "time": 166,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 166
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/integration-test/__snapshots__/golden/webTestRunUrlReplacements.test.js.snap
+++ b/integration-test/__snapshots__/golden/webTestRunUrlReplacements.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`autify web test run https://app.autify.com/projects/0000/scenarios/0000 -r "https://example.com https://example.net?foo=bar" 1`] = `
+{
+  "stderr": "",
+  "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
+[HPM] Proxy created: /  -> https://mobile-app.autify.com
+📝 Using URL replacements: https://example.com => https://example.net?foo=bar
+✅ Successfully started: https://app.autify.com/projects/743/results/1911916 (Capability is Linux Chrome 111.0)
+To wait for the test result, run the command below:
+💻 $ autify web test wait https://app.autify.com/projects/743/results/1911916
+[HPM] server close signal received: closing proxy server
+",
+}
+`;

--- a/integration-test/__snapshots__/golden/webTestRunUrlReplacementsDeprecated.test.js.snap
+++ b/integration-test/__snapshots__/golden/webTestRunUrlReplacementsDeprecated.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`autify web test run https://app.autify.com/projects/0000/scenarios/0000 -r "https://example.com=https://example.net?foo=bar" 1`] = `
+{
+  "stderr": " ›   Warning: Using = as a delimiter for --url-replacements (-r) option is 
+ ›   deprecated. Use space instead (--url-replacements "https://example.com 
+ ›   https://example.net?foo=bar").
+",
+  "stdout": "[HPM] Proxy created: /  -> https://app.autify.com
+[HPM] Proxy created: /  -> https://mobile-app.autify.com
+📝 Using URL replacements: https://example.com => https://example.net?foo=bar
+✅ Successfully started: https://app.autify.com/projects/743/results/1911917 (Capability is Linux Chrome 111.0)
+To wait for the test result, run the command below:
+💻 $ autify web test wait https://app.autify.com/projects/743/results/1911917
+[HPM] server close signal received: closing proxy server
+",
+}
+`;

--- a/integration-test/src/commands.ts
+++ b/integration-test/src/commands.ts
@@ -16,18 +16,23 @@ const concatFlagAndValue = (args: string[]) => {
   let flag = null;
   for (const arg of args) {
     if (flag !== null) {
-      if (arg.startsWith("--")) {
+      if (arg.startsWith("-")) {
         newArgs.push(flag);
         flag = arg;
         continue;
       } else {
-        newArgs.push(`${flag}=${arg}`);
+        if (flag === "-r" || flag === "--url-replacements") {
+          newArgs.push(`${flag}="${arg}"`);
+        } else {
+          newArgs.push(`${flag}=${arg}`);
+        }
+
         flag = null;
         continue;
       }
     }
 
-    if (arg.startsWith("--")) {
+    if (arg.startsWith("-")) {
       flag = arg;
       continue;
     }

--- a/integration-test/src/test/golden/webTestRunUrlReplacements.test.ts
+++ b/integration-test/src/test/golden/webTestRunUrlReplacements.test.ts
@@ -1,0 +1,6 @@
+/* eslint-disable unicorn/filename-case */
+import { testAutifyCliSnapshot } from "../helpers/testAutifyCliSnapshot";
+
+testAutifyCliSnapshot(
+  'web test run https://app.autify.com/projects/0000/scenarios/0000 -r "https://example.com https://example.net?foo=bar"'
+);

--- a/integration-test/src/test/golden/webTestRunUrlReplacementsDeprecated.test.ts
+++ b/integration-test/src/test/golden/webTestRunUrlReplacementsDeprecated.test.ts
@@ -1,0 +1,6 @@
+/* eslint-disable unicorn/filename-case */
+import { testAutifyCliSnapshot } from "../helpers/testAutifyCliSnapshot";
+
+testAutifyCliSnapshot(
+  'web test run https://app.autify.com/projects/0000/scenarios/0000 -r "https://example.com=https://example.net?foo=bar"'
+);

--- a/integration-test/src/test/helpers/execAutifyCli.ts
+++ b/integration-test/src/test/helpers/execAutifyCli.ts
@@ -21,7 +21,8 @@ const normalize = (stdout: string) =>
       /debug server on http:\/\/127.0.0.1:\d+/g,
       "debug server on http://127.0.0.1:<random>"
     )
-    .replace(/Your session ID is "[^"]+"/, 'Your session ID is "fake"');
+    .replace(/Your session ID is "[^"]+"/, 'Your session ID is "fake"')
+    .replace(/»/g, "›");
 
 export const execAutifyCli = async (
   args: string
@@ -30,6 +31,6 @@ export const execAutifyCli = async (
   const { stdout, stderr } = await promisify(exec)(command, { env });
   return {
     stdout: normalize(stripAnsi(stdout)),
-    stderr: stripAnsi(stderr),
+    stderr: normalize(stripAnsi(stderr)),
   };
 };


### PR DESCRIPTION
Internal ticket: https://app.clickup.com/t/864ea29wc

URL may contain `=` sign as a query parameter like `https://example.net?foo=bar`.
Currently we use `split("=")` to parse this option:

https://github.com/autifyhq/autify-cli/blob/abf92558fc4af017e7748a96e06daa0a916f8093/src/commands/web/test/run.ts#L14

As a result, `--url-replacements https://example.com=https://example.net?foo=bar` will be parsed as a mapping `https://example.com => https://example.net?foo`

In this case, if we add left over strings like the following, it can parse correctly

```typescript
[pattern_url, ...rest] = s.split("=");
replacement_url = rest.join("=");
```

But given URLs may be much complex like `https://example.com?foo=https://example.net?foo=https://example.net?foo` and we can't avoid ambiguity.

So, in this PR

1. Support space as a delimiter for `--url-replacements` option
2. Show deprecation warn when `=` is used as a delimiter
3. Add left over strings for `=` to improve correctness a bit

## demo

```
$ NODE_ENV=test bin/dev web test run https://app.autify.com/projects/743/scenarios/91437 --url-replacements="https://example.com=https://example.net?foo=bar"
 ›   Warning: Using = as a delimiter for --url-replacements (-r) option is deprecated. Use space instead (--url-replacements "https://example.com https://example.net?foo=bar").
📝 Using URL replacements: https://example.com => https://example.net?foo=bar
✅ Successfully started: https://app.autify.com/projects/743/results/1907744 (Capability is Linux Chrome 110.0)
To wait for the test result, run the command below:
💻 $ autify web test wait https://app.autify.com/projects/743/results/1907744

$ NODE_ENV=test bin/dev web test run https://app.autify.com/projects/743/scenarios/91437 --url-replacements="https://example.com https://example.net?foo=bar"
📝 Using URL replacements: https://example.com => https://example.net?foo=bar
✅ Successfully started: https://app.autify.com/projects/743/results/1907745 (Capability is Linux Chrome 110.0)
To wait for the test result, run the command below:
💻 $ autify web test wait https://app.autify.com/projects/743/results/1907745
```