### PR TITLE
Add --prefix option for npm install on AUTIFY_CLI_INTEGRATION_TEST_INSTALL

### DIFF
--- a/install-cicd.bash
+++ b/install-cicd.bash
@@ -91,6 +91,6 @@ if [ -n "$AUTIFY_CLI_INTEGRATION_TEST_INSTALL" ]; then
 
   cd "$AUTIFY_DIR"
   echo "Installing autify-cli-integration-test package from $package_url"
-  npm install "$package_url"
+  npm install "$package_url" --prefix "$AUTIFY_DIR"
   echo "$AUTIFY_DIR/node_modules/.bin" >> "$AUTIFY_PATH"
 fi


### PR DESCRIPTION
Currently on ci.jenkins.io, CI for our Jenkins plugin is failing with `autify-with-proxy: command not found` error.

https://github.com/jenkinsci/autify-plugin/pull/67

https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Fautify-plugin/detail/PR-67/1/pipeline/76

It seems that `npm` assumes home dir is the root and installs the `autify-with-proxy` command into `/home/jenkins`

https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Fautify-plugin/detail/PR-69/10/pipeline/33

```
[2023-04-05T09:24:14.735Z] + npm list
[2023-04-05T09:24:14.735Z] Installing autify-cli-integration-test package from https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/stable/autifyhq-autify-cli-integration-test.tgz
[2023-04-05T09:24:15.658Z] jenkins@ /home/jenkins
[2023-04-05T09:24:15.658Z] └── playwright-test@8.2.0
```

I confirmed it works with this change:

https://github.com/jenkinsci/autify-plugin/compare/cde22cae1aacb69d6159875fd9d79b22659551c3...af9e6feb82f09d4d24b9354d0dbd6195359d2da1

https://ci.jenkins.io/job/Plugins/job/autify-plugin/job/PR-69/9/execution/node/56/log/