### PR TITLE
Set prPriority for non major npm update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,8 @@
     {
       "matchDatasources": ["npm"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "all non major npm update"
+      "groupName": "all non major npm update",
+      "prPriority": 10
     },
     {
       "matchPackageNames": ["@types/express"],


### PR DESCRIPTION
I've noticed https://github.com/autifyhq/autify-cli/pull/399 is not created until I close major version bump PR like https://github.com/autifyhq/autify-cli/pull/330

I've set prPriority to get high priority

> Set sorting priority for PR creation. PRs with higher priority are created first, negative priority last.

https://docs.renovatebot.com/configuration-options/#prpriority