### PR TITLE
ADD MSYS_NO_PATHCONV=1 to fix windows build

### DIFF
--- a/install-cicd.bash
+++ b/install-cicd.bash
@@ -50,7 +50,7 @@ if [ "$OS" == "windows" ]; then
   echo "Installing CLI from $URL"
   EXE_FILE="$AUTIFY_DIR/installer.exe"
   curl "$URL" > "$EXE_FILE"
-  cmd.exe /C "$(cygpath -w "$EXE_FILE") /S /D=$(cygpath -w "$AUTIFY_DIR")"
+  MSYS_NO_PATHCONV=1 cmd.exe /C "$(cygpath -w "$EXE_FILE") /S /D=$(cygpath -w "$AUTIFY_DIR")"
 else
   mkdir "$AUTIFY_DIR/bin"
   mkdir "$AUTIFY_DIR/lib"


### PR DESCRIPTION
Currently nightly build for https://github.com/autifyhq/actions-web-test-run is failing.

https://github.com/autifyhq/actions-web-test-run/actions/workflows/nightly-test.yml
https://github.com/autifyhq/actions-web-test-run/actions/runs/5227107621/jobs/9438416832

It seems windows-latest image was updated and now it uses new version of Git for Windows.

On Git for Windows v2.41.0, `cmd.exe /C` won't run without `MSYS_NO_PATHCONV` because it converts the option to Windows path

> * If you specify command-line options starting with a slash, POSIX-to-Windows path conversion will kick in converting e.g. "`/usr/bin/bash.exe`" to "`C:\Program Files\Git\usr\bin\bash.exe`". When that is not desired -- e.g. "`--upload-pack=/opt/git/bin/git-upload-pack`" or "`-L/regex/`" -- you need to set the environment variable `MSYS_NO_PATHCONV` temporarily, like so:

  > `MSYS_NO_PATHCONV=1 git blame -L/pathconv/ msys2_path_conv.cc`

https://github.com/git-for-windows/build-extra/blob/6dc2d669d487578f75219db84e04b27293cad04a/ReleaseNotes.md#L14-L17

I confirmed CI can run successfully with this change

https://github.com/autifyhq/actions-web-test-run/pull/35