### PR TITLE
Omit default args on normalization for autify-with-proxy args

### DIFF
--- a/integration-test/src/commands.ts
+++ b/integration-test/src/commands.ts
@@ -99,5 +99,9 @@ const replaceConstants = (args: string[]) => {
   return args;
 };
 
+const DEFAULT_ARGUMENTS = new Set(["-t=300"]);
+
 export const normalizeCommand = (args: string[]): string[] =>
-  replaceConstants(concatFlagAndValue(args));
+  replaceConstants(concatFlagAndValue(args)).filter(
+    (arg) => !DEFAULT_ARGUMENTS.has(arg)
+  );


### PR DESCRIPTION
CI for https://github.com/autifyhq/autify-circleci-orb-web/pull/33 was failed because it will change default argument for `-t` option. Previously it doesn't pass `-t` but now `-t 300` is passed.

On CI it uses `autify-with-proxy` intead of actual `autify` CLI and its proxy replays recordings according to given arguments.
300 is the default value for timeout so the behavior should be the same whether this argument is given or not.

I confirmed this change fixes the CI failure:

https://github.com/autifyhq/autify-circleci-orb-web/pull/33/commits/41f045064ad08c3313169c7edb2527a7a707f6d6

![image](https://github.com/autifyhq/autify-cli/assets/1796864/646c17ee-dc00-4987-827a-ca7ce7e03cd7)
