### PR TITLE
Update node version of github action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,19 +15,19 @@ runs:
         registry-url: "https://registry.npmjs.org"
     - run: npm install
       shell: bash
-    - uses: aws-actions/configure-aws-credentials@v1-node16
+    - uses: aws-actions/configure-aws-credentials@v4
       if: ${{ inputs.aws-credentials == 'upload' }}
       with:
         role-to-assume: arn:aws:iam::434848343351:role/autify-cli-upload-only-role
         role-session-name: github-actions
         aws-region: us-west-2
-    - uses: aws-actions/configure-aws-credentials@v1-node16
+    - uses: aws-actions/configure-aws-credentials@v4
       if: ${{ inputs.aws-credentials == 'main' }}
       with:
         role-to-assume: arn:aws:iam::434848343351:role/autify-cli-beta-release-role
         role-session-name: github-actions
         aws-region: us-west-2
-    - uses: aws-actions/configure-aws-credentials@v1-node16
+    - uses: aws-actions/configure-aws-credentials@v4
       if: ${{ startsWith(inputs.aws-credentials, 'releases/') || inputs.aws-credentials == 'publish' }}
       with:
         role-to-assume: arn:aws:iam::434848343351:role/autify-cli-release-role


### PR DESCRIPTION
The node16 version is deprecated. Use the newest version of aws-actions/configure-aws-credentials