### PR TITLE
Fix CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,6 +13,11 @@ runs:
       with:
         cache: npm
         registry-url: "https://registry.npmjs.org"
+        node-version: "18.20.1"
+    # https://github.com/npm/cli/issues/7308
+    - if: runner.os == 'Windows'
+      run: npm install -g npm@9.9.3
+      shell: bash
     - run: npm install
       shell: bash
     - uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
Currently our CI is failing even on main branch.

https://github.com/autifyhq/autify-cli/actions/runs/8731062511

I noticed we use Node v18 even we have a deinition for the version here

https://github.com/autifyhq/autify-cli/blob/7236d061934e0744f25e22149608184b6b67ef8f/package.json#L177-L179

We'll need to update Node version eventually, but I'd like to fix our CI first with minimum change.

---

I confirmed it can pass with v18.20.1 but not with 18.20.2 and .3

With 18.20.3 

https://github.com/autifyhq/autify-cli/commit/34fd8b5611ae1bbb1920cab16042be1ea3c1fed3

https://github.com/autifyhq/autify-cli/actions/runs/9183977901/job/25255635925

![image](https://github.com/autifyhq/autify-cli/assets/1796864/f40e89c0-6f69-47a5-8e86-f9dee4d63f59)


With 18.20.2

https://github.com/autifyhq/autify-cli/commit/f2fcd910b1fa8a35f2c52704e74cad13665526ba

https://github.com/autifyhq/autify-cli/actions/runs/9184279256/job/25256414727

![image](https://github.com/autifyhq/autify-cli/assets/1796864/871c8015-2f44-4efb-9f38-d3c64daf56cc)

