### PR TITLE
Add lint workflow and disable rules currently violated

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,9 +2,22 @@
   "extends": ["oclif", "oclif-typescript", "prettier"],
   "rules": {
     "no-useless-constructor": "off",
+    "arrow-body-style": "off",
+    "object-shorthand": "off",
+    "prefer-destructuring": "off",
     "@typescript-eslint/no-useless-constructor": "error",
+    "@typescript-eslint/no-explicit-any": "off",
     "unicorn/prefer-top-level-await": "off",
     "unicorn/prefer-string-replace-all": "off",
-    "unicorn/prefer-event-target": "off"
+    "unicorn/prefer-event-target": "off",
+    "perfectionist/sort-objects": "off",
+    "perfectionist/sort-imports": "off",
+    "perfectionist/sort-union-types": "off",
+    "perfectionist/sort-named-imports": "off",
+    "perfectionist/sort-classes": "off",
+    "perfectionist/sort-object-types": "off",
+    "perfectionist/sort-intersection-types": "off",
+    "perfectionist/sort-interfaces": "off",
+    "n/no-process-exit": "off"
   }
 }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        type: string
+        required: true
+
+jobs:
+  branch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: ./.github/actions/setup
+      - run: npx prettier -c .
+      - run: npm run lint

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -12,6 +12,11 @@ jobs:
     with:
       branch: ${{ github.base_ref }}
 
+  lint:
+    uses: ./.github/workflows/lint.yml
+    with:
+      branch: ${{ github.base_ref }}
+
   upload:
     needs: [validate]
     uses: ./.github/workflows/upload.yml


### PR DESCRIPTION
I noticed that currently we don't have any linter/formatter on our CI and we violate some rules since some new rules have been applied with dependency updates.

Of course some of them can be easily fixed but I'd like to just fix our pre commit hook for now.