### PR TITLE
Set oclif.update.s3.host

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     },
     "update": {
       "s3": {
+        "host": "https://autify-cli-assets.s3.us-west-2.amazonaws.com",
         "bucket": "autify-cli-assets",
         "folder": "autify-cli"
       }


### PR DESCRIPTION
Promote is failing since 7369956857a20178af137cc599133bc9d10e29bd

https://github.com/autifyhq/autify-cli/actions/runs/9559981038/job/26351531483

It seems `-buildmanifest` files aren't generated if host is not set.

https://github.com/oclif/oclif/blob/7a9d680cc8b97042cdcdd101fc8c34082ae23b0d/src/tarballs/build.ts#L243


---

## Before

https://github.com/autifyhq/autify-cli/actions/runs/9738254887/job/26871565280

```
oclif: uploading targets
oclif: s3:uploadFile ./dist/autify-v0.46.0-beta.0-b2fd0c5-linux-x64.tar.gz s3://autify-cli-assets/autify-cli/versions/0.46.0-beta.0/b2fd0c5/autify-v0.46.0-beta.0-b2fd0c5-linux-x64.tar.gz
 ›   Warning: Cannot find buildmanifest /home/runner/work/autify-cli/autify-cli
 ›   /dist/autify-v0.46.0-beta.0-b2fd0c5-linux-x64-buildmanifest. CLI will not 
 ›   be able to update itself.
oclif: s3:uploadFile ./dist/autify-v0.46.0-beta.0-b2fd0c5-linux-x64.tar.xz s3://autify-cli-assets/autify-cli/versions/0.46.0-beta.0/b2fd0c5/autify-v0.46.0-beta.0-b2fd0c5-linux-x64.tar.xz
oclif: done uploading tarballs & manifests for v0.46.0-beta.0-b2fd0c5
```

## After 

https://github.com/autifyhq/autify-cli/actions/runs/9739070291/job/26873671853?pr=523

```
oclif: uploading targets
oclif: s3:uploadFile ./dist/autify-v0.46.0-beta.0-6160c35-linux-x64.tar.gz s3://autify-cli-assets/autify-cli/versions/0.46.0-beta.0/6160c35/autify-v0.46.0-beta.0-6160c35-linux-x64.tar.gz
oclif: s3:uploadFile ./dist/autify-v0.46.0-beta.0-6160c35-linux-x64-buildmanifest s3://autify-cli-assets/autify-cli/versions/0.46.0-beta.0/6160c35/autify-v0.46.0-beta.0-6160c35-linux-x64-buildmanifest
oclif: s3:uploadFile ./dist/autify-v0.46.0-beta.0-6160c35-linux-x64.tar.xz s3://autify-cli-assets/autify-cli/versions/0.46.0-beta.0/6160c35/autify-v0.46.0-beta.0-6160c35-linux-x64.tar.xz
oclif: done uploading tarballs & manifests for v0.46.0-beta.0-6160c35
```
