### PR TITLE
[PLAT-614] Improve descriptions of API commands

### DIFF
--- a/src/commands/mobile/api/run-test-plan.ts
+++ b/src/commands/mobile/api/run-test-plan.ts
@@ -12,7 +12,8 @@ export default class MobileApiRunTestPlan extends Command {
       required: true,
     }),
     "run-test-plan-request": Flags.string({
-      description: "The build_id to execute the test plan.",
+      description:
+        'A JSON object with the build_id to execute the test plan. e.g. {"build_id":"string"}',
       required: true,
     }),
   };

--- a/src/commands/web/api/create-access-point.ts
+++ b/src/commands/web/api/create-access-point.ts
@@ -14,7 +14,8 @@ export default class WebApiCreateAccessPoint extends Command {
       required: true,
     }),
     "create-access-point-request": Flags.string({
-      description: "The name of the access point to be created",
+      description:
+        'A JSON object with the name of the access point to be created e.g. {"name":"string"}',
       required: true,
     }),
   };

--- a/src/commands/web/api/create-test-plan-variable.ts
+++ b/src/commands/web/api/create-test-plan-variable.ts
@@ -14,7 +14,7 @@ export default class WebApiCreateTestPlanVariable extends Command {
     }),
     "create-test-plan-variable-request": Flags.string({
       description:
-        "The new variable key and default value to use in the test plan",
+        'A JSON object with the new variable key and default value to use in the test plan e.g. {"key":"string","default_value":"string"}',
       required: true,
     }),
   };

--- a/src/commands/web/api/create-url-replacement.ts
+++ b/src/commands/web/api/create-url-replacement.ts
@@ -13,7 +13,8 @@ export default class WebApiCreateUrlReplacement extends Command {
       required: true,
     }),
     "create-url-replacement-request": Flags.string({
-      description: "The url to replace",
+      description:
+        'A JSON object with the url to replace e.g. {"pattern_url":"string","replacement_url":"string"}',
       required: true,
     }),
   };

--- a/src/commands/web/api/delete-access-point.ts
+++ b/src/commands/web/api/delete-access-point.ts
@@ -13,7 +13,8 @@ export default class WebApiDeleteAccessPoint extends Command {
       required: true,
     }),
     "delete-access-point-request": Flags.string({
-      description: "The name of the access point to be deleted",
+      description:
+        'A JSON object with the name of the access point to be deleted e.g. {"name":"string"}',
       required: true,
     }),
   };

--- a/src/commands/web/api/execute-scenarios.ts
+++ b/src/commands/web/api/execute-scenarios.ts
@@ -14,7 +14,8 @@ export default class WebApiExecuteScenarios extends Command {
       required: true,
     }),
     "execute-scenarios-request": Flags.string({
-      description: "The scenarios and settings to execute",
+      description:
+        'A JSON object with the scenarios and settings to execute e.g. {"name":"string","execution_type":"parallel","capabilities":[{"os":"string","os_type":"macos","os_version":"string","device":"string","browser":"string","browser_type":"chrome","browser_version":"string"}],"url_replacements":[{"pattern_url":"string","replacement_url":"string"}],"scenarios":[{"id":0}],"autify_connect":{"name":"string"}}',
       required: true,
     }),
   };

--- a/src/commands/web/api/execute-schedule.ts
+++ b/src/commands/web/api/execute-schedule.ts
@@ -14,7 +14,8 @@ export default class WebApiExecuteSchedule extends Command {
       required: true,
     }),
     "execute-schedule-request": Flags.string({
-      description: "The options to execute a test plan.",
+      description:
+        'A JSON object with the options to execute a test plan. e.g. {"autify_connect":{"name":"string"}}',
       required: false,
     }),
   };

--- a/src/commands/web/api/update-test-plan-variable.ts
+++ b/src/commands/web/api/update-test-plan-variable.ts
@@ -18,7 +18,7 @@ export default class WebApiUpdateTestPlanVariable extends Command {
     }),
     "update-test-plan-variable-request": Flags.string({
       description:
-        "The variable's new key and/or default_value's value to register",
+        'A JSON object with the variable\'s new key and/or default_value\'s value to register e.g. {"key":"string","default_value":"string"}',
       required: true,
     }),
   };

--- a/src/commands/web/api/update-url-replacement.ts
+++ b/src/commands/web/api/update-url-replacement.ts
@@ -18,7 +18,7 @@ export default class WebApiUpdateUrlReplacement extends Command {
     }),
     "update-url-replacement-request": Flags.string({
       description:
-        "The url to replace. Either pattern_url or replacement_url is required.",
+        'A JSON object with the url to replace. Either pattern_url or replacement_url is required. e.g. {"pattern_url":"string","replacement_url":"string"}',
       required: true,
     }),
   };


### PR DESCRIPTION
Some API commands require object but their descriptions are vague.

For example,

```
autify mobile api run-test-plan --help
Run a test plan

USAGE
  $ autify mobile api run-test-plan --test-plan-id <value> --run-test-plan-request <value>

FLAGS
  --run-test-plan-request=<value>  (required) The build_id to execute the test plan.
  --test-plan-id=<value>           (required) The ID of the test plan to run.
```

`--run-test-plan-request` should be something like `{"build_id":"string"}` but it's difficult to understand with this message.