### PR TITLE
Add recursive option to mkdirSync

### DIFF
--- a/src/autify/connect/installClient.ts
+++ b/src/autify/connect/installClient.ts
@@ -170,7 +170,7 @@ export const installClient = async (
   // Clean up workspace in case something is left by previous command.
   if (existsSync(workspaceDir))
     rmSync(workspaceDir, { recursive: true, force: true });
-  mkdirSync(workspaceDir);
+  mkdirSync(workspaceDir, { recursive: true });
   const downloadPath = await download(workspaceDir, url);
   const extractPath = await extract(downloadPath);
   // Pre-install validation


### PR DESCRIPTION
I got the following error with [autify-circleci-orb-web](https://github.com/autifyhq/autify-circleci-orb-web)

```
Error: ENOENT: no such file or directory, mkdir 
    'C:\Users\circleci\AppData\Local\autify\autifyconnect-install-workspace'
    Code: ENOENT
```

For some reason, this error doesn't occur every time, but I think it's better to have this option.