### PR TITLE
Add `mobile link setup` command

### DIFF
--- a/src/autify/mobile/mobilelink/mobile-link-manager/MobileLinkManager.ts
+++ b/src/autify/mobile/mobilelink/mobile-link-manager/MobileLinkManager.ts
@@ -43,7 +43,7 @@ export class MobileLinkManager {
     this.logger.debug("exec");
     const version = await this.getMobiieLinkVersion();
     this.logger.info(
-      `Executing MobileLink (path: ${this.mobileLinkPath}, version: ${version})`
+      `Executing MobileLink (path: ${this.mobileLinkPath}, args: ${argv.join(" ")}, version: ${version})`
     );
     this.spawn(argv);
   }
@@ -53,13 +53,17 @@ export class MobileLinkManager {
       this.logger.debug("start");
       const version = await this.getMobiieLinkVersion();
       this.logger.info(
-        `Executing MobileLink (path: ${this.mobileLinkPath}, version: ${version})`
+        `Executing MobileLink (path: ${this.mobileLinkPath}, args: link start, version: ${version})`
       );
       this.service.send("START", { workspaceId });
     } catch (error) {
       this.service.send("FAIL", { error });
       throw error;
     }
+  }
+
+  public async setup(): Promise<void> {
+    this.exec(["link", "setup"]);
   }
 
   public async onceReady(): Promise<void> {
@@ -168,13 +172,9 @@ export class MobileLinkManager {
       },
     });
     if (connectConsole) {
-      this.childProcess.stdout.on("data", (data) => {
-        process.stdout.write(data);
-      });
-
-      this.childProcess.stderr.on("data", (data) => {
-        process.stderr.write(data);
-      });
+      this.childProcess.stdout.pipe(process.stdout);
+      this.childProcess.stderr.pipe(process.stderr);
+      process.stdin.pipe(this.childProcess.stdin);
     }
   }
 

--- a/src/commands/mobile/link/install.ts
+++ b/src/commands/mobile/link/install.ts
@@ -5,9 +5,9 @@ import {
 } from "../../../autify/mobile/mobilelink/installBinary";
 
 export default class MobileLinkInstall extends Command {
-  static description = "Install Mobile Link";
+  static description = "Install MobileLink";
   static examples = [
-    "(Recommended) Install the stable version:\n<%= config.bin %> <%= command.id %>",
+    "Install the stable version:\n<%= config.bin %> <%= command.id %>",
   ];
   static flags = {};
 

--- a/src/commands/mobile/link/setup.ts
+++ b/src/commands/mobile/link/setup.ts
@@ -1,0 +1,69 @@
+import { ux, Command } from "@oclif/core";
+import {
+  installBinary,
+  getMobileLinkSourceUrl,
+  getBinaryPath,
+} from "../../../autify/mobile/mobilelink/installBinary";
+import { MobileLinkManager } from "../../../autify/mobile/mobilelink/mobile-link-manager/MobileLinkManager";
+import { existsSync } from "node:fs";
+import {
+  getConnectClientSourceUrl,
+  getInstallPath,
+  installClient,
+} from "../../../autify/connect/installClient";
+
+export default class MobileLinkSetup extends Command {
+  static description = "Set up MobileLink";
+  static examples = [
+    "Set up MobileLink configuration:\n<%= config.bin %> <%= command.id %>",
+  ];
+
+  public async run(): Promise<void> {
+    const { configDir, cacheDir } = this.config;
+
+    const autifyConnectInstallPath = getInstallPath(configDir, cacheDir);
+    if (existsSync(autifyConnectInstallPath)) {
+      this.log(`AutifyConnect is already installed. Skipping installation`);
+    } else {
+      const { url, expectedVersion } = getConnectClientSourceUrl(
+        configDir,
+        "stable"
+      );
+      ux.action.start(
+        `Installing Autify Connect Client from ${url})`,
+        "installing",
+        { stdout: true }
+      );
+      const { version, path } = await installClient(
+        configDir,
+        cacheDir,
+        url,
+        expectedVersion
+      );
+      ux.action.stop();
+      this.log(
+        `Successfully installed Autify Connect Client (path: ${path}, version: ${version})`
+      );
+    }
+
+    if (existsSync(getBinaryPath(cacheDir))) {
+      this.log(`MobileLink is already installed. Skipping installation`);
+    } else {
+      const url = getMobileLinkSourceUrl(configDir);
+      ux.action.start(`Installing Mobile Link from ${url})`, "installing", {
+        stdout: true,
+      });
+      const { version, path } = await installBinary(cacheDir, url);
+      ux.action.stop();
+      this.log(
+        `Successfully installed Mobile Link (path: ${path}, version: ${version})`
+      );
+    }
+
+    const mobileLinkManager = new MobileLinkManager({
+      configDir,
+      cacheDir,
+    });
+    await mobileLinkManager.setup();
+  }
+}


### PR DESCRIPTION
https://autifyhq.atlassian.net/browse/MOB-2368

This patch would add a new command `mobile link setup`, which invokes the same command in the `mobikelink`. Since I want to minimize the steps users have to run, I made it run installation commands for Autify Client and MobileLink if there don't exist.

Obviously the installation code is redundant. I searched for a way to composite commands in oclif so that I can reuse another command from one command but I found nothing, unfortunately.

When yet to be installed:

```
$ ./bin/dev mobile link setup
Installing Autify Connect Client from https://autifyconnect.s3.ap-northeast-1.amazonaws.com/autifyconnect/versions/stable/autifyconnect_darwin_arm64.tar.gz)... done
Successfully installed Autify Connect Client (path: /Users/tai2/Library/Caches/autify/autifyconnect, version: Autify Connect version v1.1.34, build b4b3f90)
Installing Mobile Link from https://d21jojv86oc6d1.cloudfront.net/mobilelink/channels/stable/mobilelink-darwin-arm64.tar.gz)... done
Successfully installed Mobile Link (path: /Users/tai2/Library/Caches/autify/mobilelink, version: mobilelink/0.2.1 darwin-arm64 node-v22.14.0)
[Mobile Link Manager]     2025-03-19T04:41:03.639Z      info    Executing MobileLink (path: /Users/tai2/Library/Caches/autify/mobilelink/bin/mobilelink, args: link setup, version: mobilelink/0.2.1 darwin-arm64 node-v22.14.0)
Starting the initial setup...
✓ Xcode version: 16.2
? Enter your personal access token for Nocode Mobile. You can issue a token from
✔ Enter your personal access token for Nocode Mobile. You can issue a token from
 the following URL.
https://mobile-app.autify.com/settings/token
(If you press Enter, the current value (*****tzr) will be used.)
> 
Skipped.
? setup.input_message.project_id
✔ setup.input_message.project_id
(If you press Enter, the current value (nYmF1n) will be used.)
> 
Skipped.
? Enter the Team ID of the Apple Developer Program to use for testing iOS apps. 
✔ Enter the Team ID of the Apple Developer Program to use for testing iOS apps. 
You can check the Team ID from the following URL.
https://developer.apple.com/account#MembershipDetailsCard
(If you press Enter, the current value (7XV69VPSD3) will be used.)
> 
Skipped.
? Enter the Signing ID of the Apple Developer Program to use for testing iOS 
✔ Enter the Signing ID of the Apple Developer Program to use for testing iOS 
apps. The default is 'Apple Development'.
(If you press Enter, the default value will be set.)
> 
Skipped.
? Enter the Bundle ID of WebDriverAgent to use for testing iOS apps. The default
✔ Enter the Bundle ID of WebDriverAgent to use for testing iOS apps. The default
 is 'com.autify.WebDriverAgentRunner'. This Bundle ID must be associated with a 
valid provisioning profile.
(If you press Enter, the default value will be set.)
> 
Skipped.
The initial setup is complete.
```

When already installed:

```
$ ./bin/dev mobile link setup
AutifyConnect is already installed. Skipping installation
MobileLink is already installed. Skipping installation
[Mobile Link Manager]     2025-03-19T04:52:13.606Z      info    Executing MobileLink (path: /Users/tai2/Library/Caches/autify/mobilelink/bin/mobilelink, args: link setup, version: mobilelink/0.2.1 darwin-arm64 node-v22.14.0)
Starting the initial setup...
✓ Xcode version: 16.2
? Enter your personal access token for Nocode Mobile. You can issue a token from
✔ Enter your personal access token for Nocode Mobile. You can issue a token from
 the following URL.
https://mobile-app.autify.com/settings/token
(If you press Enter, the current value (*****tzr) will be used.)
> 
Skipped.
? setup.input_message.project_id
✔ setup.input_message.project_id
(If you press Enter, the current value (nYmF1n) will be used.)
> 
Skipped.
? Enter the Team ID of the Apple Developer Program to use for testing iOS apps. 
✔ Enter the Team ID of the Apple Developer Program to use for testing iOS apps. 
You can check the Team ID from the following URL.
https://developer.apple.com/account#MembershipDetailsCard
(If you press Enter, the current value (7XV69VPSD3) will be used.)
> 
Skipped.
? Enter the Signing ID of the Apple Developer Program to use for testing iOS 
✔ Enter the Signing ID of the Apple Developer Program to use for testing iOS 
apps. The default is 'Apple Development'.
(If you press Enter, the default value will be set.)
> 
Skipped.
? Enter the Bundle ID of WebDriverAgent to use for testing iOS apps. The default
✔ Enter the Bundle ID of WebDriverAgent to use for testing iOS apps. The default
 is 'com.autify.WebDriverAgentRunner'. This Bundle ID must be associated with a 
valid provisioning profile.
(If you press Enter, the default value will be set.)
> 
Skipped.
The initial setup is complete.
```