### PR TITLE
[chore] Remove @oclif/errors dependency and use @oclif/core instead

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
       "dependencies": {
         "@autifyhq/autify-sdk": "^0.25.0",
         "@oclif/core": "^3.27.0",
-        "@oclif/errors": "^1.3.6",
         "@oclif/plugin-help": "^6.2.27",
         "@oclif/plugin-not-found": "^3.2.47",
         "@oclif/plugin-update": "^4.6.35",
@@ -3975,21 +3974,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@oclif/errors": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.6.tgz",
-      "integrity": "sha512-fYaU4aDceETd89KXP+3cLyg9EHZsLD3RxF2IU9yxahhBpspWjkWi3Dy3bTgcwZ3V47BgxQaGapzJWDM33XIVDQ==",
-      "dependencies": {
-        "clean-stack": "^3.0.0",
-        "fs-extra": "^8.1",
-        "indent-string": "^4.0.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@oclif/plugin-help": {
@@ -10008,6 +9992,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -10021,6 +10006,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -10029,6 +10015,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -20236,18 +20223,6 @@
         }
       }
     },
-    "@oclif/errors": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.6.tgz",
-      "integrity": "sha512-fYaU4aDceETd89KXP+3cLyg9EHZsLD3RxF2IU9yxahhBpspWjkWi3Dy3bTgcwZ3V47BgxQaGapzJWDM33XIVDQ==",
-      "requires": {
-        "clean-stack": "^3.0.0",
-        "fs-extra": "^8.1",
-        "indent-string": "^4.0.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
     "@oclif/plugin-help": {
       "version": "6.2.27",
       "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.27.tgz",
@@ -24712,6 +24687,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -24722,6 +24698,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
           }
@@ -24729,7 +24706,8 @@
         "universalify": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@autifyhq/autify-sdk": "^0.25.0",
     "@oclif/core": "^3.27.0",
-    "@oclif/errors": "^1.3.6",
     "@oclif/plugin-help": "^6.2.27",
     "@oclif/plugin-not-found": "^3.2.47",
     "@oclif/plugin-update": "^4.6.35",

--- a/src/autify/connect/accessPointConfig.ts
+++ b/src/autify/connect/accessPointConfig.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/filename-case */
-import { CLIError } from "@oclif/errors";
+import { Errors } from "@oclif/core";
 import inquirer from "inquirer";
 import { get, set } from "../../config";
 
@@ -18,7 +18,7 @@ export const confirmOverwriteAccessPoint = async (
       },
     ]);
     if (!res.confirmed) {
-      throw new CLIError(
+      throw new Errors.CLIError(
         `Cancelled to overwrite the existing Access Point. It stays as is (name: ${existingName})`
       );
     }

--- a/src/autify/connect/client-manager/ClientManager.ts
+++ b/src/autify/connect/client-manager/ClientManager.ts
@@ -1,6 +1,6 @@
 /* eslint-disable unicorn/filename-case */
 import { WebClient } from "@autifyhq/autify-sdk";
-import { CLIError } from "@oclif/errors";
+import { Errors } from "@oclif/core";
 import { ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { env } from "node:process";
 import { EventEmitter } from "node:stream";
@@ -54,7 +54,7 @@ export type ProcessExit = Readonly<{
   code: number | null;
   signal: NodeJS.Signals | null;
 }>;
-export class StateMachineTimeoutError extends CLIError {
+export class StateMachineTimeoutError extends Errors.CLIError {
   constructor(state: string) {
     super(`Autify Connect Manager faced timeout at ${state} state.`);
   }
@@ -95,7 +95,7 @@ export class ClientManager {
     const name = get(options.configDir, "AUTIFY_CONNECT_ACCESS_POINT_NAME");
     const key = get(options.configDir, "AUTIFY_CONNECT_ACCESS_POINT_KEY");
     if (!name || !key)
-      throw new CLIError(
+      throw new Errors.CLIError(
         "Access Point is not saved. Run `autify connect access-point create/set` first."
       );
     const accessPoint = createStaticAccessPoint(name, key);
@@ -322,7 +322,7 @@ export class ClientManager {
         }
       );
     } catch {
-      throw new CLIError(
+      throw new Errors.CLIError(
         `Unknown state transition: ${this.service.getSnapshot().value}`
       );
     }

--- a/src/autify/connect/client-manager/DebugServerClient.ts
+++ b/src/autify/connect/client-manager/DebugServerClient.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/filename-case */
-import { CLIError } from "@oclif/errors";
+import { Errors } from "@oclif/core";
 import { ClientEvents } from "./ClientManager";
 import AbortController from "abort-controller";
 
@@ -38,7 +38,7 @@ export class DebugServerClient {
     const req = { method: "GET", path: "/status" };
     const res = (await this.request(req)) as DebugServerStatusResponse;
     if (res.status && res.message) return res;
-    throw new CLIError(
+    throw new Errors.CLIError(
       `Invalid response from ${JSON.stringify(req)}: ${JSON.stringify(res)}`
     );
   }
@@ -62,7 +62,7 @@ export class DebugServerClient {
     }
 
     if (response.ok) return response.json();
-    throw new CLIError(
+    throw new Errors.CLIError(
       `Request to debug server failed: ${method} ${path} => ${response.status} ${response.statusText}`
     );
   }

--- a/src/autify/connect/installClient.ts
+++ b/src/autify/connect/installClient.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/filename-case */
-import { CLIError } from "@oclif/errors";
+import { Errors } from "@oclif/core";
 import { arch, env, platform } from "node:process";
 import {
   createReadStream,
@@ -27,7 +27,7 @@ const getMode = (configDir: string): ClientMode => {
   const mode = get(configDir, "AUTIFY_CONNECT_CLIENT_MODE");
   if (!mode) return "real";
   if (!["fake", "real"].includes(mode))
-    throw new CLIError(
+    throw new Errors.CLIError(
       `Unknown value is specified by AUTIFY_CONNECT_CLIENT_MODE: ${mode}`
     );
   return mode as ClientMode;
@@ -38,14 +38,14 @@ const getOs = () => {
   if (os === "linux") return "linux";
   if (os === "darwin") return "darwin";
   if (os === "win32") return "windows";
-  throw new CLIError(`Unsupported OS: ${os}`);
+  throw new Errors.CLIError(`Unsupported OS: ${os}`);
 };
 
 const getArch = () => {
   if (arch === "ia32") return "386";
   if (arch === "x64") return "amd64";
   if (arch === "arm64") return "arm64";
-  throw new CLIError(`Unsupported Architecture: ${arch}`);
+  throw new Errors.CLIError(`Unsupported Architecture: ${arch}`);
 };
 
 const getExt = () => (getOs() === "windows" ? "zip" : "tar.gz");
@@ -80,7 +80,7 @@ const download = async (workspaceDir: string, url: URL) => {
   const downloadPath = join(workspaceDir, basename(url.pathname));
   const response = await fetch(url);
   if (!response.ok)
-    throw new CLIError(`Failed to fetch ${url}: ${response.status}`);
+    throw new Errors.CLIError(`Failed to fetch ${url}: ${response.status}`);
   const streamPipeline = promisify(pipeline);
   if (response.body) {
     await streamPipeline(response.body, createWriteStream(downloadPath));
@@ -102,17 +102,17 @@ const extract = async (downloadPath: string) => {
       Extract({ path: dir })
     );
   } else {
-    throw new CLIError(`Unsupported file format: ${downloadPath}`);
+    throw new Errors.CLIError(`Unsupported file format: ${downloadPath}`);
   }
 
   const files = readdirSync(dir);
   const binary = files.find((file) => file.startsWith("autifyconnect"));
   if (!binary)
-    throw new CLIError(`Cannot find any autifyconnect binary in ${dir}`);
+    throw new Errors.CLIError(`Cannot find any autifyconnect binary in ${dir}`);
   return join(dir, binary);
 };
 
-export class ConnectClientVersionMismatchError extends CLIError {
+export class ConnectClientVersionMismatchError extends Errors.CLIError {
   constructor(
     readonly expected: string,
     readonly reality: string
@@ -147,7 +147,7 @@ export const getInstallPath = (configDir: string, cacheDir: string): string => {
 
 export const getInstallVersion = async (path: string): Promise<string> => {
   if (!existsSync(path)) {
-    throw new CLIError(
+    throw new Errors.CLIError(
       `Autify Connect Client isn't installed yet at ${path}. Run \`autify connect client install\` first.`
     );
   }
@@ -156,7 +156,7 @@ export const getInstallVersion = async (path: string): Promise<string> => {
     env,
   });
   const version = stderr.trim();
-  if (version === "") throw new CLIError("Version is empty");
+  if (version === "") throw new Errors.CLIError("Version is empty");
   return version;
 };
 

--- a/src/autify/mobile/createZip.ts
+++ b/src/autify/mobile/createZip.ts
@@ -1,6 +1,6 @@
 /* eslint-disable unicorn/filename-case */
 
-import { CLIError } from "@oclif/errors";
+import { Errors } from "@oclif/core";
 import { execFileSync } from "node:child_process";
 import { createWriteStream, lstatSync } from "node:fs";
 import { basename, dirname, resolve, join } from "node:path";
@@ -13,7 +13,9 @@ import { mkdtemp } from "node:fs/promises";
 
 const checkBuildPath = (buildPath: string) => {
   if (!lstatSync(buildPath).isDirectory()) {
-    throw new CLIError(`Build path (${buildPath}) is expected to directory.`);
+    throw new Errors.CLIError(
+      `Build path (${buildPath}) is expected to directory.`
+    );
   }
 
   const parentPath = resolve(dirname(buildPath));
@@ -48,7 +50,7 @@ export const createZip = async (buildPath: string): Promise<string> => {
     const zipStream = new StreamZip.async({ file: zipFile });
     await zipStream.close();
   } catch (error) {
-    throw new CLIError(
+    throw new Errors.CLIError(
       `Failed to create a valid zip file (${zipFile}): ${error}`
     );
   }

--- a/src/autify/mobile/inspectBuildFile.ts
+++ b/src/autify/mobile/inspectBuildFile.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/filename-case */
-import { CLIError } from "@oclif/errors";
+import { Errors } from "@oclif/core";
 import { lstatSync } from "node:fs";
 import { createZip } from "./createZip";
 
@@ -18,7 +18,9 @@ const isAndroidApp = (buildPath: string) => {
 const getOs = (buildPath: string) => {
   if (isIosApp(buildPath)) return "ios";
   if (isAndroidApp(buildPath)) return "android";
-  throw new CLIError(`${buildPath} doesn't look like iOS app nor Android apk.`);
+  throw new Errors.CLIError(
+    `${buildPath} doesn't look like iOS app nor Android apk.`
+  );
 };
 
 const getUploadPath = async (buildPath: string, os: "ios" | "android") => {
@@ -28,7 +30,7 @@ const getUploadPath = async (buildPath: string, os: "ios" | "android") => {
   }
 
   if (os === "android") return buildPath;
-  throw new CLIError(`Invalid os: ${os}`);
+  throw new Errors.CLIError(`Invalid os: ${os}`);
 };
 
 export const inspectBuildFile = async (

--- a/src/autify/mobile/mobilelink/installBinary.ts
+++ b/src/autify/mobile/mobilelink/installBinary.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/filename-case */
-import { CLIError } from "@oclif/errors";
+import { Errors } from "@oclif/core";
 import { arch, env, platform } from "node:process";
 import {
   createReadStream,
@@ -23,14 +23,14 @@ const getOs = () => {
   if (os === "linux") return "linux";
   if (os === "darwin") return "darwin";
   if (os === "win32") return "windows";
-  throw new CLIError(`Unsupported OS: ${os}`);
+  throw new Errors.CLIError(`Unsupported OS: ${os}`);
 };
 
 const getArch = () => {
   if (arch === "ia32") return "386";
   if (arch === "x64") return "amd64";
   if (arch === "arm64") return "arm64";
-  throw new CLIError(`Unsupported Architecture: ${arch}`);
+  throw new Errors.CLIError(`Unsupported Architecture: ${arch}`);
 };
 
 const getExt = () => (getOs() === "windows" ? "zip" : "tar.gz");
@@ -56,7 +56,7 @@ const download = async (workspaceDir: string, url: URL) => {
   if (!response.ok) {
     const b = await response.text();
     console.log("response doby!!!", b);
-    throw new CLIError(`Failed to fetch ${url}: ${response.status}`);
+    throw new Errors.CLIError(`Failed to fetch ${url}: ${response.status}`);
   }
 
   const streamPipeline = promisify(pipeline);
@@ -80,14 +80,14 @@ const extract = async (downloadPath: string) => {
       Extract({ path: dir })
     );
   } else {
-    throw new CLIError(`Unsupported file format: ${downloadPath}`);
+    throw new Errors.CLIError(`Unsupported file format: ${downloadPath}`);
   }
 
   const binDir = join(dir, "mobilelink", "bin");
   const files = readdirSync(binDir);
   const binary = files.find((file) => file.startsWith("mobilelink"));
   if (!binary)
-    throw new CLIError(`Cannot find any mobilelink binary in ${binDir}`);
+    throw new Errors.CLIError(`Cannot find any mobilelink binary in ${binDir}`);
   return join(dir, "mobilelink");
 };
 
@@ -105,7 +105,7 @@ export const getBinaryPath = (cacheDir: string): string => {
 
 export const getInstallVersion = async (path: string): Promise<string> => {
   if (!existsSync(path)) {
-    throw new CLIError(
+    throw new Errors.CLIError(
       `MobileLink isn't installed yet at ${path}. Run \`autify mobile link install\` first.`
     );
   }
@@ -114,7 +114,7 @@ export const getInstallVersion = async (path: string): Promise<string> => {
     env,
   });
   const version = stdout.trim();
-  if (version === "") throw new CLIError("Version is empty");
+  if (version === "") throw new Errors.CLIError("Version is empty");
   return version;
 };
 

--- a/src/autify/mobile/mobilelink/mobile-link-manager/MobileLinkManager.ts
+++ b/src/autify/mobile/mobilelink/mobile-link-manager/MobileLinkManager.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/filename-case */
-import { CLIError } from "@oclif/errors";
+import { Errors } from "@oclif/core";
 import { ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { env } from "node:process";
 import { EventEmitter } from "node:stream";
@@ -27,7 +27,7 @@ export type ProcessExit = Readonly<{
   code: number | null;
   signal: NodeJS.Signals | null;
 }>;
-export class StateMachineTimeoutError extends CLIError {
+export class StateMachineTimeoutError extends Errors.CLIError {
   constructor(state: string) {
     super(`MobileLink Manager faced timeout at ${state} state.`);
   }
@@ -244,7 +244,7 @@ export class MobileLinkManager {
         }
       );
     } catch {
-      throw new CLIError(
+      throw new Errors.CLIError(
         `Unknown state transition: ${this.service.getSnapshot().value}`
       );
     }

--- a/src/autify/mobile/parseTestPlanUrl.ts
+++ b/src/autify/mobile/parseTestPlanUrl.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/filename-case */
-import { CLIError } from "@oclif/errors";
+import { Errors } from "@oclif/core";
 
 export const parseTestPlanUrl = (
   url: string
@@ -13,6 +13,7 @@ export const parseTestPlanUrl = (
   const match = testPlanUrlPathRegExp.exec(pathname);
   const workspaceId = match?.groups?.workspaceId;
   const testPlanId = match?.groups?.testPlanId;
-  if (!workspaceId || !testPlanId) throw new CLIError(`Invalid URL: ${url}`);
+  if (!workspaceId || !testPlanId)
+    throw new Errors.CLIError(`Invalid URL: ${url}`);
   return { workspaceId, testPlanId };
 };

--- a/src/autify/mobile/parseTestResultUrl.ts
+++ b/src/autify/mobile/parseTestResultUrl.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/filename-case */
-import { CLIError } from "@oclif/errors";
+import { Errors } from "@oclif/core";
 
 export const parseTestResultUrl = (
   url: string
@@ -10,6 +10,7 @@ export const parseTestResultUrl = (
   const match = testResultUrlPathRegExp.exec(pathname);
   const workspaceId = match?.groups?.workspaceId;
   const resultId = match?.groups?.resultId;
-  if (!workspaceId || !resultId) throw new CLIError(`Invalid URL: ${url}`);
+  if (!workspaceId || !resultId)
+    throw new Errors.CLIError(`Invalid URL: ${url}`);
   return { workspaceId, resultId };
 };

--- a/src/autify/mobile/uploadBuild.ts
+++ b/src/autify/mobile/uploadBuild.ts
@@ -1,6 +1,6 @@
 /* eslint-disable unicorn/filename-case */
 import { MobileClient } from "@autifyhq/autify-sdk";
-import { CLIError } from "@oclif/errors";
+import { Errors } from "@oclif/core";
 import { inspectBuildFile } from "./inspectBuildFile";
 
 export const uploadBuild = async (
@@ -10,6 +10,6 @@ export const uploadBuild = async (
 ): Promise<[string, "ios" | "android"]> => {
   const [uploadPath, os] = await inspectBuildFile(buildPath);
   const res = await client.uploadBuild(workspaceId, uploadPath);
-  if (!res.data.id) throw new CLIError(`Failed to upload ${buildPath}.`);
+  if (!res.data.id) throw new Errors.CLIError(`Failed to upload ${buildPath}.`);
   return [res.data.id, os];
 };

--- a/src/autify/mobile/waitTestResult.ts
+++ b/src/autify/mobile/waitTestResult.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/filename-case */
-import { CLIError } from "@oclif/errors";
+import { Errors } from "@oclif/core";
 import Listr, { ListrTaskWrapper } from "listr";
 import { setInterval } from "node:timers/promises";
 import { MobileClient } from "@autifyhq/autify-sdk";
@@ -22,7 +22,9 @@ const waitUntil = async <T>(
           )) {
             const now = Date.now();
             if (now - startTime > timeoutSecond * 1000) {
-              throw new CLIError(`Timeout after ${timeoutSecond} seconds.`);
+              throw new Errors.CLIError(
+                `Timeout after ${timeoutSecond} seconds.`
+              );
             }
 
             const result = await callback(task);

--- a/src/autify/web/parseAutifyTestUrl.ts
+++ b/src/autify/web/parseAutifyTestUrl.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/filename-case */
-import { CLIError } from "@oclif/errors";
+import { Errors } from "@oclif/core";
 
 const parseTestScenarioUrl = (url: string) => {
   const { pathname } = new URL(url);
@@ -40,5 +40,5 @@ export const parseAutifyTestUrl = (url: string): TestScenario | TestPlan => {
   const testPlan = parseTestPlanUrl(url);
   if (testScenario) return testScenario;
   if (testPlan) return testPlan;
-  throw new CLIError(`Invalid URL: ${url}`);
+  throw new Errors.CLIError(`Invalid URL: ${url}`);
 };

--- a/src/autify/web/parseTestResultUrl.ts
+++ b/src/autify/web/parseTestResultUrl.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/filename-case */
-import { CLIError } from "@oclif/errors";
+import { Errors } from "@oclif/core";
 
 export const parseTestResultUrl = (
   url: string
@@ -10,6 +10,7 @@ export const parseTestResultUrl = (
   const match = testResultUrlPathRegExp.exec(pathname);
   const workspaceId = Number.parseInt(match?.groups?.workspaceId ?? "", 10);
   const resultId = Number.parseInt(match?.groups?.resultId ?? "", 10);
-  if (!workspaceId || !resultId) throw new CLIError(`Invalid URL: ${url}`);
+  if (!workspaceId || !resultId)
+    throw new Errors.CLIError(`Invalid URL: ${url}`);
   return { workspaceId, resultId };
 };

--- a/src/autify/web/runTest.ts
+++ b/src/autify/web/runTest.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/filename-case */
-import { CLIError } from "@oclif/errors";
+import { Errors } from "@oclif/core";
 import { WebClient } from "@autifyhq/autify-sdk";
 import { TestPlan, TestScenario } from "./parseAutifyTestUrl";
 
@@ -35,11 +35,11 @@ const getCapability = async (
     .filter((c) => !option.device || c.device === option.device)
     .filter((c) => !option.device_type || c.device_type === option.device_type);
   if (candidates.length === 0)
-    throw new CLIError(
+    throw new Errors.CLIError(
       `No capability is available for: ${JSON.stringify(option)}`
     );
   if (candidates.length > 1)
-    throw new CLIError(
+    throw new Errors.CLIError(
       `Multiple capabilities are available for: ${JSON.stringify(
         option
       )} => ${JSON.stringify(candidates)}`
@@ -98,13 +98,15 @@ export const runTest = async (
 
   if (testPlanId) {
     if (isCapabilitySpecified(option))
-      throw new CLIError(
+      throw new Errors.CLIError(
         `Running TestPlan doesn't support capability override: ${JSON.stringify(
           option
         )}`
       );
     if (name)
-      throw new CLIError(`Running TestPlan doesn't support --name: ${name}`);
+      throw new Errors.CLIError(
+        `Running TestPlan doesn't support --name: ${name}`
+      );
     const urlReplacementIds = [];
     for await (const urlReplacement of urlReplacements ?? []) {
       const res = await client.createUrlReplacement(testPlanId, urlReplacement);
@@ -129,5 +131,5 @@ export const runTest = async (
     };
   }
 
-  throw new CLIError("testScenarioId or testPlanId is required.");
+  throw new Errors.CLIError("testScenarioId or testPlanId is required.");
 };

--- a/src/autify/web/waitTestResult.ts
+++ b/src/autify/web/waitTestResult.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/filename-case */
-import { CLIError } from "@oclif/errors";
+import { Errors } from "@oclif/core";
 import Listr, { ListrTaskWrapper } from "listr";
 import { setInterval } from "node:timers/promises";
 import { WebClient } from "@autifyhq/autify-sdk";
@@ -27,11 +27,14 @@ const waitUntil = async <T>(
             intervalSecond * 1000,
             Date.now()
           )) {
-            if (killed) throw new CLIError(`Process was killed by ${killed}.`);
+            if (killed)
+              throw new Errors.CLIError(`Process was killed by ${killed}.`);
 
             const now = Date.now();
             if (now - startTime > timeoutSecond * 1000) {
-              throw new CLIError(`Timeout after ${timeoutSecond} seconds.`);
+              throw new Errors.CLIError(
+                `Timeout after ${timeoutSecond} seconds.`
+              );
             }
 
             const result = await callback(task);

--- a/src/commands/mobile/test/run.ts
+++ b/src/commands/mobile/test/run.ts
@@ -1,5 +1,4 @@
-import { Command, Args, Flags } from "@oclif/core";
-import { CLIError } from "@oclif/errors";
+import { Command, Args, Flags, Errors } from "@oclif/core";
 import * as emoji from "node-emoji";
 import { getMobileClient } from "../../../autify/mobile/getMobileClient";
 import { getMobileTestResultUrl } from "../../../autify/mobile/getTestResultUrl";
@@ -73,7 +72,7 @@ export default class MobileTestRun extends Command {
         // eslint-disable-next-line camelcase
         build_id: buildId,
       });
-      if (!res.data.id) throw new CLIError(`Failed to run a test plan.`);
+      if (!res.data.id) throw new Errors.CLIError(`Failed to run a test plan.`);
       const testResultUrl = getMobileTestResultUrl(
         configDir,
         workspaceId,
@@ -96,11 +95,11 @@ export default class MobileTestRun extends Command {
         try {
           await MobileTestWait.run(waitArgs);
         } catch (error) {
-          if ((error as CLIError).oclif.exit === 0) return null;
+          if ((error as Errors.CLIError).oclif.exit === 0) return null;
           return error as Error;
         }
 
-        throw new CLIError(`Unexpected behavior.`);
+        throw new Errors.CLIError(`Unexpected behavior.`);
       };
 
       const maxRetryCount = flags["max-retry-count"];

--- a/src/commands/web/test/run.ts
+++ b/src/commands/web/test/run.ts
@@ -1,9 +1,8 @@
-import { Command, Args, Flags } from "@oclif/core";
+import { Command, Args, Flags, Errors } from "@oclif/core";
 import * as emoji from "node-emoji";
 import { runTest } from "../../../autify/web/runTest";
 import { getWebTestResultUrl } from "../../../autify/web/getTestResultUrl";
 import WebTestWait from "./wait";
-import { CLIError } from "@oclif/errors";
 import { parseAutifyTestUrl } from "../../../autify/web/parseAutifyTestUrl";
 import { ClientManager } from "../../../autify/connect/client-manager/ClientManager";
 import { getWebClient } from "../../../autify/web/getWebClient";
@@ -191,11 +190,11 @@ export default class WebTestRun extends Command {
           try {
             await WebTestWait.run(waitArgs);
           } catch (error) {
-            if ((error as CLIError).oclif.exit === 0) return null;
+            if ((error as Errors.CLIError).oclif.exit === 0) return null;
             return error as Error;
           }
 
-          throw new CLIError(`Unexpected behavior.`);
+          throw new Errors.CLIError(`Unexpected behavior.`);
         };
 
         const maxRetryCount = flags["max-retry-count"];
@@ -257,7 +256,7 @@ export default class WebTestRun extends Command {
             `Use space instead (--url-replacements "${pattern_url} ${replacement_url}").`
         );
       } else {
-        throw new CLIError(
+        throw new Errors.CLIError(
           `Can't parse ${s} as --url-replacements option. Please make sure it has a space as a delimiter and surrounded by quotes. (e.g. --url-replacements "https://example.com https://example.net")`
         );
       }


### PR DESCRIPTION
This PR removes the @oclif/errors dependency as it's deprecated and its functionality is now covered by @oclif/core. All imports of CLIError have been updated to use Errors.CLIError from @oclif/core instead.