### PR TITLE
Add doctor command

### DIFF
--- a/src/autify/mobile/mobilelink/mobile-link-manager/MobileLinkManager.ts
+++ b/src/autify/mobile/mobilelink/mobile-link-manager/MobileLinkManager.ts
@@ -66,6 +66,10 @@ export class MobileLinkManager {
     this.exec(["link", "setup"]);
   }
 
+  public async doctor(): Promise<void> {
+    this.exec(["link", "doctor"]);
+  }
+
   public async onceReady(): Promise<void> {
     this.logger.debug("onceReady");
     await this.once("ready");

--- a/src/commands/mobile/link/doctor.ts
+++ b/src/commands/mobile/link/doctor.ts
@@ -1,0 +1,19 @@
+import { Command } from "@oclif/core";
+import { MobileLinkManager } from "../../../autify/mobile/mobilelink/mobile-link-manager/MobileLinkManager";
+
+export default class MobileLinkDoctor extends Command {
+  static description = "Check MobileLink configuration";
+  static examples = [
+    "Check MobileLink configuration:\n<%= config.bin %> <%= command.id %>",
+  ];
+
+  public async run(): Promise<void> {
+    const { configDir, cacheDir } = this.config;
+
+    const mobileLinkManager = new MobileLinkManager({
+      configDir,
+      cacheDir,
+    });
+    await mobileLinkManager.doctor();
+  }
+}


### PR DESCRIPTION
https://autifyhq.atlassian.net/browse/MOB-2368

This patch would add `mobile link doctor` command which verifies the configuration on local device execution.

```
$ ./bin/dev mobile link doctor
[Mobile Link Manager]     2025-03-19T07:00:48.808Z      info    Executing MobileLink (path: /Users/tai2/Library/Caches/autify/mobilelink/bin/mobilelink, args: link doctor, version: mobilelink/0.2.1 darwin-arm64 node-v22.14.0)
✔ Xcode is installed.
✔ Xcode Command Line Tools are installed.
✔ Xcode version: 16.2
✔ Connected iOS device(s) found:
  - Taiju’s iPhone (00008030-0008459A0A3B802E)
✔ Access token is valid.
✔ All checks passed. ✔
```