### PR TITLE
Pass AUTIFY_CLI_INTEGRATION variable and others

### DIFF
--- a/src/autify/mobile/mobilelink/mobile-link-manager/MobileLinkManager.ts
+++ b/src/autify/mobile/mobilelink/mobile-link-manager/MobileLinkManager.ts
@@ -279,7 +279,6 @@ export class MobileLinkManager {
 
   private get integrationVariables() {
     return {
-      AUTIFY_CLI_INTEGRATION: "true",
       AUTIFY_CONNECT_BIN_PATH: this.autifyConnectPath,
       AUTIFY_MOBILE_ACCESS_TOKEN: this.accessToken,
     };


### PR DESCRIPTION
https://autifyhq.atlassian.net/browse/MOB-2368

~This patch would make Autify CLI pass the `AUTIFY_CLI_INTEGRATION` and other variables to MobileLink so that it can receive necessary information from Autify CLI and change the behavior.~ As a result of a discussion in #4531, I stopped specifying the `AUTIFY_CLI_INTEGRATION` variable.

See https://github.com/autifyhq/mobile-web/pull/4531 as well

The reason I don't pass extra variables on `link exec` is I want to keep the original behavior since it's low layer.

----

The necessary steps for setup for users will look like this:

```
autify mobile auth
autify mobile link setup # users don't need to run `install` commands explicitly
autify mobile start
```

In a separate terminal

```
autify mobile run $TEST_PLAN_URL --device_ids 00008030-0008459A0A3B802E
```