### PR TITLE
Fix: some information from MobileLink is dropped

### DIFF
--- a/src/autify/mobile/mobilelink/mobile-link-manager/Logger.ts
+++ b/src/autify/mobile/mobilelink/mobile-link-manager/Logger.ts
@@ -72,7 +72,17 @@ export const setupMobileLinkOutputLogger = (
     crlfDelay: Number.POSITIVE_INFINITY,
   }).on("line", (line) => {
     try {
-      callback(JSON.parse(line) as ClientLog);
+      const data = JSON.parse(line);
+      const level = data.level;
+      const timestamp = data.timestamp;
+      delete data.level;
+      delete data.timestamp;
+      const log: ClientLog = {
+        level,
+        timestamp,
+        message: JSON.stringify(data),
+      };
+      callback(log);
     } catch {
       callback({
         level: "info",


### PR DESCRIPTION
I've noticed some information in the logs from mobilelink is dropped. This is because the structured logs of mobilelink contain properties other than messages but Autify CLI presumes it contains only messages. This patch would include all information in the logs.

Before

```
[Mobile Link]             2025-03-31T03:04:13.168Z      info    Found device
[Mobile Link]             2025-03-31T03:04:13.168Z      info    Found device
[Mobile Link]             2025-03-31T03:04:13.168Z      info    Found device
[Mobile Link]             2025-03-31T03:04:13.168Z      info    Found device
```

After

```
[Mobile Link]             2025-03-31T03:03:05.237Z      info    {"deviceId":"4285F3C0-2624-4215-B982-EE0F5C8266BA","isRealDevice":false,"message":"Found device","name":"iPad Air (4th generation)","os":"ios","osVersion":"15.2"}
[Mobile Link]             2025-03-31T03:03:05.237Z      info    {"deviceId":"2447FA95-AE8E-43AD-B338-439EAF320157","isRealDevice":false,"message":"Found device","name":"iPad Pro (9.7-inch)","os":"ios","osVersion":"15.2"}
[Mobile Link]             2025-03-31T03:03:05.237Z      info    {"deviceId":"65C6397F-D32A-4867-8EFE-AF5CD340BA1A","isRealDevice":false,"message":"Found device","name":"iPod touch (7th generation)","os":"ios","osVersion":"15.2"}
```

