### PR TITLE
Fix: wrong file name of mobilelink on intel

### DIFF
--- a/src/autify/mobile/mobilelink/installBinary.ts
+++ b/src/autify/mobile/mobilelink/installBinary.ts
@@ -31,7 +31,7 @@ const getOs = () => {
 
 const getArch = () => {
   if (arch === "ia32") return "386";
-  if (arch === "x64") return "amd64";
+  if (arch === "x64") return "x64";
   if (arch === "arm64") return "arm64";
   throw new Errors.CLIError(`Unsupported Architecture: ${arch}`);
 };


### PR DESCRIPTION
Ticket: https://autifyhq.atlassian.net/browse/MOB-2439

`autify mobile link install` fails with this error:

```
Installing Mobile Link from https://d21jojv86oc6d1.cloudfront.net/mobilelink/channels/stable/mobilelink-darwin-amd64.tar.gz)... !
›   Error: Failed to fetch https://d21jojv86oc6d1.cloudfront.net/mobilelink/ch
›   annels/stable/mobilelink-darwin-amd64.tar.gz: 403
```