### PR TITLE
Fix: E2E test always last 15 minutes

### DIFF
--- a/e2e-test/mobile/local-execution-flow.test.ts
+++ b/e2e-test/mobile/local-execution-flow.test.ts
@@ -122,35 +122,33 @@ test("NoCode Mobile local device test execution flow", async () => {
     // Ensure MobileLink gets ready
     await delay(20_000);
 
-    await interactWithProcess(
-      getAutifyCliPath(),
-      [
-        "mobile",
-        "test",
-        "run",
-        "--build-id",
-        BUILD_ID,
-        "--wait",
-        "--timeout",
-        TIMEOUT_SECONDS.toString(),
-        "--device-ids",
-        simulator.udid,
-        TEST_PLAN_URL,
-      ],
-      [
-        {
-          type: "expect",
-          regex: /Test passed!/,
-        },
-      ]
-    );
-
-    terminateStartProcess();
+    try {
+      await interactWithProcess(
+        getAutifyCliPath(),
+        [
+          "mobile",
+          "test",
+          "run",
+          "--build-id",
+          BUILD_ID,
+          "--wait",
+          "--timeout",
+          TIMEOUT_SECONDS.toString(),
+          "--device-ids",
+          simulator.udid,
+          TEST_PLAN_URL,
+        ],
+        [
+          {
+            type: "expect",
+            regex: /Test passed!/,
+          },
+        ]
+      );
+    } finally {
+      terminateStartProcess();
+    }
   };
-
-  // Test doesn't start in the TIMEOUT_SECONDS sometimes. To ensure E2E to finish in a reasonable time, we terminate
-  // MobileLink so that the test can fail.
-  setTimeout(terminateStartProcess, TIMEOUT_SECONDS * 1000);
 
   await Promise.all([startMobileLinkResult, runTest()]);
 });


### PR DESCRIPTION
I've noticed there's a mistake and E2E test always lasts more than 15 minutes even if it's finished early.