### PR TITLE
bump mobile link version

### DIFF
--- a/src/autify/mobile/mobilelink/installBinary.ts
+++ b/src/autify/mobile/mobilelink/installBinary.ts
@@ -18,8 +18,8 @@ import { execFile } from "node:child_process";
 import * as tar from "tar";
 import { get } from "../../../config";
 
-const MOBILE_LINK_VERSION = "0.3.0";
-const MOBILE_LINK_HASH = "26f64f82d";
+const MOBILE_LINK_VERSION = "0.3.1";
+const MOBILE_LINK_HASH = "6de575a31";
 
 const getOs = () => {
   const os = platform;


### PR DESCRIPTION
Update Mobile Link version to newest release:
https://github.com/autifyhq/mobile-web/pull/4556 add persistent list of local devices on start command
https://github.com/autifyhq/mobile-web/pull/4558 bump mobile link version to 0.3.1