### PR TITLE
Bump mobilelink to 0.4.6

### DIFF
--- a/src/autify/mobile/mobilelink/installBinary.ts
+++ b/src/autify/mobile/mobilelink/installBinary.ts
@@ -18,8 +18,8 @@ import { execFile } from "node:child_process";
 import * as tar from "tar";
 import { get } from "../../../config";
 
-const MOBILE_LINK_VERSION = "0.4.5";
-const MOBILE_LINK_HASH = "14f3442c4";
+const MOBILE_LINK_VERSION = "0.4.6";
+const MOBILE_LINK_HASH = "df6643a14";
 
 const getArch = () => {
   if (arch === "ia32") return "386";


### PR DESCRIPTION
It contains a fix for the local Android device.

cf https://github.com/autifyhq/mobile-web/pull/4707