### PR TITLE
Update MobileLink to 0.5.0

### DIFF
--- a/src/autify/mobile/mobilelink/installBinary.ts
+++ b/src/autify/mobile/mobilelink/installBinary.ts
@@ -18,8 +18,8 @@ import { execFile } from "node:child_process";
 import * as tar from "tar";
 import { get } from "../../../config";
 
-const MOBILE_LINK_VERSION = "0.4.7";
-const MOBILE_LINK_HASH = "c26f6c33d";
+const MOBILE_LINK_VERSION = "0.5.0";
+const MOBILE_LINK_HASH = "cb291e9cf";
 
 const getArch = () => {
   if (arch === "ia32") return "386";


### PR DESCRIPTION
This patch would update MobileLink to 0.5.0 which brings verbose log capability for Autify Connect

https://github.com/autifyhq/mobile-web/pull/4850