### PR TITLE
Streamline deployment workflows

### DIFF
--- a/.github/workflows/merge-bump.yml
+++ b/.github/workflows/merge-bump.yml
@@ -7,14 +7,8 @@ on:
       - bump/rc/*
 
 jobs:
-  approved:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Approved!"
-
   merge-bump:
     runs-on: ubuntu-latest
-    needs: [approved]
     steps:
       - id: generate-token
         uses: tibdex/github-app-token@v2

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -34,16 +34,3 @@ jobs:
   github-actions-tests:
     needs: [upload]
     uses: ./.github/workflows/github-actions-tests.yml
-
-  approved:
-    needs: [integration-tests, e2e-tests, github-actions-tests]
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          if [[ "${{ needs.integration-tests.result }}" == "success" && "${{ needs.e2e-tests.result }}" == "success" ]]; then
-            echo "Approved!"
-          else
-            echo "Not approved!"
-            exit 1
-          fi


### PR DESCRIPTION
The `approved` workflow depends on `integration-tests` and `e2e-tests` workflows.
It is made "required" through branch protection settings.

I will change it to require those workflows directly instead.