### PR TITLE
Configure npm with minimum release age

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - uses: ./.github/actions/setup
-    - run: npm install
+    - run: npm ci
       shell: bash
     - run: npm run release install ${{ inputs.target }}
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,22 +9,14 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
-      with:
-        cache: npm
-        registry-url: "https://registry.npmjs.org"
-        node-version-file: "package.json"
-        node-version: 22
-    # https://github.com/npm/cli/issues/7308
-    - if: runner.os == 'Windows'
-      run: npm install -g npm@9.9.3
-      shell: bash
+    # https://github.com/jdx/mise-action/releases/tag/v4.0.1
+    - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
     # Install setuptools for node-gyp on Windows (required by os-proxy-config dependency)
     # Python 3.12+ removed distutils, but setuptools provides it
     - if: runner.os == 'Windows'
       run: pip install setuptools
       shell: bash
-    - run: npm install
+    - run: npm ci
       shell: bash
     - uses: aws-actions/configure-aws-credentials@v4
       if: ${{ inputs.aws-credentials == 'upload' }}

--- a/.github/actions/upload/action.yml
+++ b/.github/actions/upload/action.yml
@@ -15,7 +15,7 @@ runs:
     - if: ${{ inputs.target == 'win' }}
       run: sudo apt-get install nsis
       shell: bash
-    - run: npm install
+    - run: npm ci
       shell: bash
     - run: npm run release upload ${{ inputs.target }}
       shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,5 +31,4 @@ jobs:
           aws-credentials: publish
       - run: git config --global user.name "${GITHUB_ACTOR}"
       - run: git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-      - run: npm install -g npm@latest
       - run: npm run release publish

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -11,5 +11,5 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           aws-credentials: releases/*
-      - run: npm install
+      - run: npm ci
       - run: npm run release rollback

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age = 3

--- a/integration-test/.npmrc
+++ b/integration-test/.npmrc
@@ -1,0 +1,1 @@
+min-release-age = 3

--- a/mise.lock
+++ b/mise.lock
@@ -1,0 +1,12 @@
+[[tools.node]]
+version = "22.22.2"
+backend = "core:node"
+"platforms.linux-arm64" = { checksum = "sha256:b2f3a96f31486bfc365192ad65ced14833ad2a3c2e1bcefec4846902f264fa28", url = "https://nodejs.org/dist/v22.22.2/node-v22.22.2-linux-arm64.tar.gz"}
+"platforms.linux-x64" = { checksum = "sha256:978978a635eef872fa68beae09f0aad0bbbae6757e444da80b570964a97e62a3", url = "https://nodejs.org/dist/v22.22.2/node-v22.22.2-linux-x64.tar.gz"}
+"platforms.macos-arm64" = { checksum = "sha256:db4b275b83736df67533529a18cc55de2549a8329ace6c7bcc68f8d22d3c9000", url = "https://nodejs.org/dist/v22.22.2/node-v22.22.2-darwin-arm64.tar.gz"}
+"platforms.macos-x64" = { checksum = "sha256:12a6abb9c2902cf48a21120da13f87fde1ed1b71a13330712949e8db818708ba", url = "https://nodejs.org/dist/v22.22.2/node-v22.22.2-darwin-x64.tar.gz"}
+"platforms.windows-x64" = { checksum = "sha256:7c93e9d92bf68c07182b471aa187e35ee6cd08ef0f24ab060dfff605fcc1c57c", url = "https://nodejs.org/dist/v22.22.2/node-v22.22.2-win-x64.zip"}
+
+[[tools.npm]]
+version = "11.12.1"
+backend = "npm:npm"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,6 @@
+[tools]
+node = "22"
+npm = "11"
+
+[settings]
+locked = true


### PR DESCRIPTION
Add `.npmrc` file with `min-release-age` config to mitigate supply chain attacks.

https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age

In order to make sure this config is being used in CI, we have to ensure that a newer version of npm is being used. Previously the npm version was not pinned anywhere and sometimes updated to latest on the fly, so I've reworked the node setup to use `mise` with a lock file in order to ensure the correct versions are used.

Also changed the instances of `npm install` to `npm ci` to ensure lock files are respected and builds exit with an error if there are any discrepancies.