### PR TITLE
Fix workflow permissions

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   id-token: write
+  contents: read
 
 jobs:
   # Open/update the Version PR if pending changesets exist, otherwise signal

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   lint:
     uses: ./.github/workflows/lint.yml


### PR DESCRIPTION
Fixes a permission issue with the changeset workflow that prevented it from reading other workflows: https://github.com/autifyhq/autify-cli/actions/runs/25709251111

Also adds explicit permissions to the pull-requests workflow (not required for the fix but otherwise it was dependent on repo settings).