### PR TITLE
Fix publish script breaking on newline

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -44,20 +44,8 @@ jobs:
           version: |
             npx changeset version
             npx oclif readme --repository-prefix='<%- repo %>/blob/@autifyhq/autify-cli@<%- version %>/<%- commandPath %>'
-          # Signal "release this version" by emitting a `New tag:` line that the
-          # action parses to determine published packages. The conditional makes
-          # this idempotent — if the current version already has a tag, no
-          # release is triggered (so pushes to main without a changeset are
-          # harmless).
-          publish: |
-            VERSION=$(jq -r .version package.json)
-            TAG="@autifyhq/autify-cli@${VERSION}"
-            git fetch --tags --quiet
-            if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
-              echo "Tag ${TAG} already exists, skipping release"
-            else
-              echo "New tag: ${TAG}"
-            fi
+          # Publish must be a single command (action splits on whitespace).
+          publish: bash scripts/changesets-detect-publish.sh
           createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
@@ -90,12 +78,8 @@ jobs:
       - name: Create GitHub release
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
-          # The action scans stdout for `New tag:` lines and creates a GitHub
-          # release for each one. We only want a release for the CLI itself,
-          # not the integration-test workspace package.
-          publish: |
-            VERSION=$(jq -r .version package.json)
-            echo "New tag: @autifyhq/autify-cli@${VERSION}"
+          # Only tag the CLI itself, not the integration-test workspace.
+          publish: bash scripts/changesets-tag.sh
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/scripts/changesets-detect-publish.sh
+++ b/scripts/changesets-detect-publish.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Idempotency check for changesets/action's publish step.
+# Emits `New tag:` only when the current version isn't tagged yet,
+# so subsequent pushes without a changeset are no-ops.
+set -euo pipefail
+
+VERSION=$(jq -r .version package.json)
+TAG="@autifyhq/autify-cli@${VERSION}"
+
+git fetch --tags --quiet
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+  echo "Tag ${TAG} already exists, skipping release"
+else
+  echo "New tag: ${TAG}"
+fi

--- a/scripts/changesets-tag.sh
+++ b/scripts/changesets-tag.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Emits `New tag:` for changesets/action to create the GitHub release.
+set -euo pipefail
+
+VERSION=$(jq -r .version package.json)
+echo "New tag: @autifyhq/autify-cli@${VERSION}"


### PR DESCRIPTION
Refactor the publish step in the GitHub Actions workflow to use dedicated scripts for tagging and publishing, ensuring proper handling of newlines and idempotency.

Fixes the error seen on main: https://github.com/autifyhq/autify-cli/actions/runs/25710914645/job/75490759417