### PR TITLE
Fix changeset release tag

### DIFF
--- a/autify-cli/scripts/changesets-tag.sh
+++ b/autify-cli/scripts/changesets-tag.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
-# Emits `New tag:` for changesets/action to create the GitHub release.
+# Creates the release tag locally and emits `New tag:` so changesets/action
+# pushes it and creates the matching GitHub release.
 set -euo pipefail
 
 VERSION=$(jq -r .version "$(dirname "$0")/../package.json")
-echo "New tag: @autifyhq/autify-cli@${VERSION}"
+TAG="@autifyhq/autify-cli@${VERSION}"
+
+if ! git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+  git tag "${TAG}"
+fi
+echo "New tag: ${TAG}"


### PR DESCRIPTION
Release job failed because the tag was not created locally, so it failed to push anything: https://github.com/autifyhq/autify-cli/actions/runs/25770797107/job/75694413085