### PR TITLE
fix(ci): trust the autifyhq tap before installing the brew build

### DIFF
--- a/autify-cli/scripts/release.ts
+++ b/autify-cli/scripts/release.ts
@@ -301,6 +301,9 @@ const installBrew = () => {
   run(`mkdir -p ${tap}/Formula`);
   updateBrewFormula("autify-cli.rb");
   run(`cp autify-cli.rb ${tap}/Formula/`);
+  // Homebrew refuses to load formulae from non-official taps until they are
+  // trusted, and the formula being installed is the one written just above.
+  run("brew trust --tap autifyhq/tap");
   run("brew install -v -d autify-cli");
 };
 


### PR DESCRIPTION
The brew integration test has failed on every run since 10 Jul, last passing on 22 Jun. Homebrew gained a trust model for third-party taps in the meantime, and the macOS runner image picked it up, so loading the formula now fails outright:

```
Refusing to load formula autifyhq/tap/autify-cli from untrusted tap autifyhq/tap.
```

Nothing in the repo changed to cause it, which is why it looks unrelated to whatever PR it fails on. The real message is also buried above a Ruby backtrace and a Node execSync stack, so the log tail only shows `Error: Command failed: brew install -v -d autify-cli`.

Trusting the tap before installing is the supported escape hatch. It is non-interactive, only recording the entry in a local trust file, so nothing needs suppressing in CI. Trusting the tap rather than the individual formula also survives a formula rename. No environment variable turns the check off, so an explicit call is the only route.

Worth noting separately: this affects real installs too. Anyone running `brew install autifyhq/tap/autify-cli` on a current Homebrew hits the same refusal and needs `brew trust autifyhq/tap` first, so the install docs likely need the same step.
