### PR TITLE
ci: pin the e2e runner to macOS 15 and trust the tap before the brew install

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,8 +15,13 @@ jobs:
     strategy:
       matrix:
         include:
+          # Pinned to macOS 15. On the macOS 26 image the app download outruns
+          # bsdtar, and appium-xcuitest-driver 8.4.3 registers no error listener
+          # on its stdin, so the resulting EPIPE becomes an uncaught exception
+          # and kills the Appium server mid-session. Safe to move back to
+          # macos-latest-xlarge once mobilelink ships a driver that handles it.
           - target: darwin-arm64
-            os: macos-latest-xlarge
+            os: macos-15-xlarge
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/autify-cli/scripts/release.ts
+++ b/autify-cli/scripts/release.ts
@@ -301,6 +301,9 @@ const installBrew = () => {
   run(`mkdir -p ${tap}/Formula`);
   updateBrewFormula("autify-cli.rb");
   run(`cp autify-cli.rb ${tap}/Formula/`);
+  // Homebrew refuses to load formulae from non-official taps until they are
+  // trusted, and the formula being installed is the one written just above.
+  run("brew trust --tap autifyhq/tap");
   run("brew install -v -d autify-cli");
 };
 


### PR DESCRIPTION
Two CI fixes that have to land together, because each job is red for the reason the other one fixes.

## Pinning the e2e runner to macOS 15

The `macos-latest-xlarge` label migrated from `macos-15-arm64` to `macos-26-arm64` between 22 Jun and 10 Jul, and the e2e job has failed on every run since. Nothing in this repo or in mobilelink changed across that boundary:

- 22 Jun, `macos-15-arm64`, Xcode 16.4 — passes, no `EPIPE` anywhere in the run
- 4 Aug and 12 Aug, `macos-26-arm64`, Xcode 26.6 — `EPIPE` every run, fatal
- identical mobilelink `0.6.6`, identical bundled `node-v22.22.3`, identical test app

On the newer image the app download outruns `bsdtar`, which exits as soon as it has the archive, so the trailing write raises `EPIPE`. `appium-xcuitest-driver` 8.4.3 registers no error listener on that stream, so it escalates to an uncaught exception and kills the Appium server mid-session. MobileLink then tears down the session and the CLI waits out its full 1200s timeout, which is why it surfaces as a timeout rather than an error.

Selecting an older Xcode does not help. The crash happens during app extraction, before any simulator work, and `bsdtar` comes from the OS rather than the toolchain — the `macos-26` image also only ships Xcode 26.x.

`macos-15-arm64` has no deprecation badge and no retirement issue open, and GitHub maintains the latest two macOS versions, so the label should hold until macOS 27 images land.

## Trusting the tap before the brew install

Homebrew gained a trust model for third-party taps, so loading the formula now fails outright:

```
Refusing to load formula autifyhq/tap/autify-cli from untrusted tap autifyhq/tap.
```

The brew integration test has failed on every run since 10 Jul for this reason, last passing on 22 Jun. Trusting the tap first is the supported escape hatch — non-interactive, only recording the entry in a local trust file. Trusting the tap rather than the individual formula also survives a formula rename.

This affects real installs too: anyone running `brew install autifyhq/tap/autify-cli` on a current Homebrew hits the same refusal, so the install docs need the same step.

---

The runner pin is a workaround rather than a fix, and it does mean the e2e stops exercising the OS customers are migrating to. The underlying `EPIPE` defect is three lines in the driver and is tracked separately.
