### PR TITLE
[MOB-3638] Extend the central Renovate base preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>autifyhq/dependency-update-control-plane//renovate-config/default",
-    "config:recommended"
-  ],
+  "extends": ["github>autifyhq/dependency-update-control-plane//renovate-config/default"],
   "packageRules": [
     {
       "matchDatasources": ["npm"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": [
+    "github>autifyhq/dependency-update-control-plane//renovate-config/default",
+    "config:recommended"
+  ],
   "packageRules": [
     {
       "matchDatasources": ["npm"],


### PR DESCRIPTION
https://autifyhq.atlassian.net/browse/MOB-3638

Reference the control plane's shared **base preset** as the first `extends` entry — the **Renovate-config convergence** step. This repo's own `extends` + top-level config still layer on top and **win**; the preset only supplies the common base (grouping, labels, `rangeStrategy`, `dependencyDashboard`).

```json
"extends": [
  "github>autifyhq/dependency-update-control-plane//renovate-config/default",
  ...existing...
]
```

## ⚠️ Prerequisite before merge
**Disable Mend-hosted Renovate for this repo first.** The preset lives in the **private** `dependency-update-control-plane` repo; Mend can't read it without an org-owner grant, so merging while Mend still runs would make Renovate **error** resolving config. Disabling Mend hands resolution to the self-hosted control-plane runner (`CONTROL_PLANE_GH_TOKEN`), which can read the private preset. Don't merge until then.

Config-only; the existing base alias (`config:base`/`config:recommended`) is now redundant since the preset already provides it, but left in place to keep this diff minimal.