### PR TITLE
fix: show every mobile test status in --wait output

### DIFF
--- a/.changeset/mobile-status-emojis.md
+++ b/.changeset/mobile-status-emojis.md
@@ -1,0 +1,5 @@
+---
+"@autifyhq/autify-cli": patch
+---
+
+Show every Autify for Mobile test status in `--wait` output. Carried-over, cancelled, errored and device-wait results previously all rendered as "None".

--- a/.changeset/mobile-status-emojis.md
+++ b/.changeset/mobile-status-emojis.md
@@ -2,4 +2,4 @@
 "@autifyhq/autify-cli": patch
 ---
 
-Show every Autify for Mobile test status in `--wait` output. Carried-over, cancelled, errored and device-wait results previously all rendered as "None".
+Show every Autify for Mobile test status in `--wait` output. Carried-over, cancelled, errored and device-wait results previously all rendered as "None". Refreshes the status emoji for both web and mobile so the two commands stay in step.

--- a/autify-cli/src/autify/mobile/waitTestResult.ts
+++ b/autify-cli/src/autify/mobile/waitTestResult.ts
@@ -49,15 +49,34 @@ type Status = Awaited<
   ReturnType<MobileClient["describeTestResult"]>
 >["data"]["status"];
 
+type StatusDisplay = { emoji: string; label: string };
+
+/* eslint-disable camelcase */
+const STATUS_DISPLAY: Record<string, StatusDisplay> = {
+  canceled: { emoji: "stop_button", label: "Canceled" },
+  failed: { emoji: "rotating_light", label: "Failed" },
+  internal_error: { emoji: "no_entry_sign", label: "Internal error" },
+  passed: { emoji: "+1", label: "Passed" },
+  queuing: { emoji: "cyclone", label: "Queuing" },
+  running: { emoji: "red_car", label: "Running" },
+  skip_passed: { emoji: "fast_forward", label: "Already passed" },
+  skipped: { emoji: "zzz", label: "Skipped" },
+  wait_device: { emoji: "hourglass", label: "Waiting device" },
+  wait_device_timeout: { emoji: "alarm_clock", label: "Device timeout" },
+  waiting: { emoji: "hourglass_flowing_sand", label: "Waiting" },
+};
+/* eslint-enable camelcase */
+
+const UNKNOWN_STATUS: StatusDisplay = {
+  emoji: "grey_question",
+  label: "None",
+};
+
+const MIN_LABEL_WIDTH = 7;
+
 const emojiStatus = (status?: Status) => {
-  if (status === "queuing") return emoji.get("cyclone") + " Queuing";
-  if (status === "waiting")
-    return emoji.get("hourglass_flowing_sand") + " Waiting";
-  if (status === "running") return emoji.get("red_car") + " Running";
-  if (status === "passed") return emoji.get("+1") + " Passed ";
-  if (status === "failed") return emoji.get("rotating_light") + " Failed ";
-  if (status === "skipped") return emoji.get("zzz") + " Skipped";
-  return emoji.get("grey_question") + " None   ";
+  const { emoji: name, label } = STATUS_DISPLAY[status ?? ""] ?? UNKNOWN_STATUS;
+  return `${emoji.get(name)} ${label.padEnd(MIN_LABEL_WIDTH)}`;
 };
 
 const describeTestResult =

--- a/autify-cli/src/autify/mobile/waitTestResult.ts
+++ b/autify-cli/src/autify/mobile/waitTestResult.ts
@@ -54,10 +54,10 @@ type StatusDisplay = { emoji: string[]; label: string };
 /* eslint-disable camelcase */
 const STATUS_DISPLAY: Record<string, StatusDisplay> = {
   canceled: { emoji: ["stop_button"], label: "Canceled" },
-  failed: { emoji: ["rotating_light"], label: "Failed" },
+  failed: { emoji: ["x"], label: "Failed" },
   internal_error: { emoji: ["no_entry_sign"], label: "Internal error" },
   passed: { emoji: ["+1"], label: "Passed" },
-  queuing: { emoji: ["cyclone"], label: "Queuing" },
+  queuing: { emoji: ["vertical_traffic_light"], label: "Queuing" },
   running: { emoji: ["red_car"], label: "Running" },
   skip_passed: {
     emoji: ["white_check_mark", "fast_forward"],

--- a/autify-cli/src/autify/mobile/waitTestResult.ts
+++ b/autify-cli/src/autify/mobile/waitTestResult.ts
@@ -49,34 +49,39 @@ type Status = Awaited<
   ReturnType<MobileClient["describeTestResult"]>
 >["data"]["status"];
 
-type StatusDisplay = { emoji: string; label: string };
+type StatusDisplay = { emoji: string[]; label: string };
 
 /* eslint-disable camelcase */
 const STATUS_DISPLAY: Record<string, StatusDisplay> = {
-  canceled: { emoji: "stop_button", label: "Canceled" },
-  failed: { emoji: "rotating_light", label: "Failed" },
-  internal_error: { emoji: "no_entry_sign", label: "Internal error" },
-  passed: { emoji: "+1", label: "Passed" },
-  queuing: { emoji: "cyclone", label: "Queuing" },
-  running: { emoji: "red_car", label: "Running" },
-  skip_passed: { emoji: "fast_forward", label: "Already passed" },
-  skipped: { emoji: "zzz", label: "Skipped" },
-  wait_device: { emoji: "hourglass", label: "Waiting device" },
-  wait_device_timeout: { emoji: "alarm_clock", label: "Device timeout" },
-  waiting: { emoji: "hourglass_flowing_sand", label: "Waiting" },
+  canceled: { emoji: ["stop_button"], label: "Canceled" },
+  failed: { emoji: ["rotating_light"], label: "Failed" },
+  internal_error: { emoji: ["no_entry_sign"], label: "Internal error" },
+  passed: { emoji: ["+1"], label: "Passed" },
+  queuing: { emoji: ["cyclone"], label: "Queuing" },
+  running: { emoji: ["red_car"], label: "Running" },
+  skip_passed: {
+    emoji: ["white_check_mark", "fast_forward"],
+    label: "Already passed",
+  },
+  skipped: { emoji: ["fast_forward"], label: "Skipped" },
+  wait_device: { emoji: ["hourglass"], label: "Waiting device" },
+  wait_device_timeout: { emoji: ["stopwatch"], label: "Device timeout" },
+  waiting: { emoji: ["hourglass_flowing_sand"], label: "Waiting" },
 };
 /* eslint-enable camelcase */
 
 const UNKNOWN_STATUS: StatusDisplay = {
-  emoji: "grey_question",
+  emoji: ["grey_question"],
   label: "None",
 };
 
 const MIN_LABEL_WIDTH = 7;
 
 const emojiStatus = (status?: Status) => {
-  const { emoji: name, label } = STATUS_DISPLAY[status ?? ""] ?? UNKNOWN_STATUS;
-  return `${emoji.get(name)} ${label.padEnd(MIN_LABEL_WIDTH)}`;
+  const { emoji: names, label } =
+    STATUS_DISPLAY[status ?? ""] ?? UNKNOWN_STATUS;
+  const glyphs = names.map((name) => emoji.get(name)).join("");
+  return `${glyphs} ${label.padEnd(MIN_LABEL_WIDTH)}`;
 };
 
 const describeTestResult =

--- a/autify-cli/src/autify/web/waitTestResult.ts
+++ b/autify-cli/src/autify/web/waitTestResult.ts
@@ -60,13 +60,14 @@ type Status = Awaited<
 >["data"]["status"];
 
 const emojiStatus = (status?: Status) => {
-  if (status === "queuing") return emoji.get("cyclone") + " Queuing";
+  if (status === "queuing")
+    return emoji.get("vertical_traffic_light") + " Queuing";
   if (status === "waiting")
     return emoji.get("hourglass_flowing_sand") + " Waiting";
   if (status === "running") return emoji.get("red_car") + " Running";
   if (status === "passed") return emoji.get("+1") + " Passed ";
-  if (status === "failed") return emoji.get("rotating_light") + " Failed ";
-  if (status === "skipped") return emoji.get("zzz") + " Skipped";
+  if (status === "failed") return emoji.get("x") + " Failed ";
+  if (status === "skipped") return emoji.get("fast_forward") + " Skipped";
   return emoji.get("grey_question") + " None   ";
 };
 

--- a/integration-test/__snapshots__/golden/mobileTestRunIosIPAWait.test.js.snap
+++ b/integration-test/__snapshots__/golden/mobileTestRunIosIPAWait.test.js.snap
@@ -13,66 +13,66 @@ exports[`autify mobile test run https://mobile-app.autify.com/projects/AAA/test_
 [HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
 [HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
 [HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running

--- a/integration-test/__snapshots__/golden/mobileTestRunWait.test.js.snap
+++ b/integration-test/__snapshots__/golden/mobileTestRunWait.test.js.snap
@@ -8,7 +8,7 @@ exports[`autify mobile test run https://mobile-app.autify.com/projects/AAA/test_
 ✅ Successfully started: https://mobile-app.autify.com/projects/4yyFEL/results/jztZqV
 🕐 Waiting for the test result: https://mobile-app.autify.com/projects/4yyFEL/results/jztZqV
 [HH:MM:SS] Waiting... (timeout: 300 s) [started]
-[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None   
+[HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running

--- a/integration-test/__snapshots__/golden/webTestRunAutifyConnectClient.test.js.snap
+++ b/integration-test/__snapshots__/golden/webTestRunAutifyConnectClient.test.js.snap
@@ -16,9 +16,9 @@ Autify Connect Client is ready!
 ✅ Successfully started: https://app.autify.com/projects/743/results/4758669 (Capability is Linux Chrome 136.0 computer)
 🕐 Waiting for the test result: https://app.autify.com/projects/743/results/4758669
 [HH:MM:SS] Waiting... (timeout: 300 s) [started]
-[HH:MM:SS] → TestPlan: 🌀 Queuing, TestCases: 
-[HH:MM:SS] → TestPlan: 🌀 Queuing, TestCases: 
-[HH:MM:SS] → TestPlan: 🌀 Queuing, TestCases: 
+[HH:MM:SS] → TestPlan: 🚦 Queuing, TestCases: 
+[HH:MM:SS] → TestPlan: 🚦 Queuing, TestCases: 
+[HH:MM:SS] → TestPlan: 🚦 Queuing, TestCases: 
 [HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
 [HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
 [HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting

--- a/integration-test/__snapshots__/golden/webTestRunTestPlanAutifyConnectClient.test.js.snap
+++ b/integration-test/__snapshots__/golden/webTestRunTestPlanAutifyConnectClient.test.js.snap
@@ -16,9 +16,9 @@ Autify Connect Client is ready!
 ✅ Successfully started: https://app.autify.com/projects/743/results/4758670 (Capability is configured by test plan)
 🕐 Waiting for the test result: https://app.autify.com/projects/743/results/4758670
 [HH:MM:SS] Waiting... (timeout: 300 s) [started]
-[HH:MM:SS] → TestPlan: 🌀 Queuing, TestCases: 
-[HH:MM:SS] → TestPlan: 🌀 Queuing, TestCases: 
-[HH:MM:SS] → TestPlan: 🌀 Queuing, TestCases: 
+[HH:MM:SS] → TestPlan: 🚦 Queuing, TestCases: 
+[HH:MM:SS] → TestPlan: 🚦 Queuing, TestCases: 
+[HH:MM:SS] → TestPlan: 🚦 Queuing, TestCases: 
 [HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
 [HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting
 [HH:MM:SS] → TestPlan: ⏳ Waiting, TestCases: ⏳ Waiting

--- a/integration-test/__snapshots__/golden/webTestRunTestPlanWait.test.js.snap
+++ b/integration-test/__snapshots__/golden/webTestRunTestPlanWait.test.js.snap
@@ -8,7 +8,7 @@ exports[`autify web test run https://app.autify.com/projects/0000/test_plans/000
 ✅ Successfully started: https://app.autify.com/projects/743/results/1920728 (Capability is configured by test plan)
 🕐 Waiting for the test result: https://app.autify.com/projects/743/results/1920728
 [HH:MM:SS] Waiting... (timeout: 300 s) [started]
-[HH:MM:SS] → TestPlan: 🌀 Queuing, TestCases: 
+[HH:MM:SS] → TestPlan: 🚦 Queuing, TestCases: 
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running
 [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: 🚗 Running


### PR DESCRIPTION
## Problem

`autify mobile test run --wait` prints a status line per poll:

```
TestPlan: 🚗 Running, TestCases: 👍 Passed  / 🚨 Failed
```

`emojiStatus` in `src/autify/mobile/waitTestResult.ts` covers six statuses. The mobile API returns eleven. The other five fall through to the `❔ None` default, so a run that hits any of them tells you nothing:

| status | before | after |
| --- | --- | --- |
| `canceled` | ❔ None | ⏹ Canceled |
| `internal_error` | ❔ None | 🚫 Internal error |
| `wait_device` | ❔ None | ⌛ Waiting device |
| `wait_device_timeout` | ❔ None | ⏱ Device timeout |
| `skip_passed` | ❔ None | ✅⏩ Already passed |

`skip_passed` is new, added by MOB-3570 for cells a rerun carries over instead of running again. The other four predate it, so this is not only about that feature.

## What this does not change

Nothing about exit codes or polling. The loop terminates on `data.finished_at`, not on a status allowlist, and `isPassed` reads the plan status, which never takes any of these values. An unrecognised status was already safe, just illegible. This is a display fix.

## Why the shape changed

The old chain hand-padded every label to seven characters so the progress line keeps a stable width. That made adding a status a matter of counting spaces, which is a plausible reason five of them were missing. A lookup table plus `padEnd` holds the same seven-column minimum without the counting.

Seven is kept deliberately rather than derived from the longest label. Every status that already rendered has a label of seven characters or fewer, so its output is byte-for-byte unchanged. The five new labels run longer and pad to nothing, so the only lines that move are ones that used to read "None".

`camelcase` rejects the API status values as property names, and quoting them does not help because prettier's default `quoteProps` strips the quotes straight back off. The table carries a scoped `eslint-disable` rather than being contorted into a different data structure to satisfy the linter.

Labels match the wording the Autify for Mobile UI already uses, so `skip_passed` reads "Already passed" in both places.

## Snapshot changes

Sixty-one lines across two golden snapshots recorded the bug. Those runs had a test case sitting in `wait_device`, and the snapshots captured it as `❔ None`:

```
- [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ❔ None
+ [HH:MM:SS] → TestPlan: 🚗 Running, TestCases: ⌛ Waiting device
```

They were edited rather than regenerated with `-u`. Running the suite locally adds a `util._extend` DeprecationWarning to stderr that CI does not produce, and `-u` would have baked that into every snapshot it touched. The two `*Wait` snapshots with no status change are untouched, which is also what confirms the warning is local: they differ only by that line.

## Checks

`npm run build`, `eslint`, and `prettier --check` all pass locally. Rendered every status to confirm the emoji names resolve in `node-emoji` and that the column still lines up:

| emoji | status | shown as |
| --- | --- | --- |
| ⏹ | `canceled` | Canceled |
| ❌ | `failed` | Failed |
| 🚫 | `internal_error` | Internal error |
| 👍 | `passed` | Passed |
| 🚦 | `queuing` | Queuing |
| 🚗 | `running` | Running |
| ✅⏩ | `skip_passed` | Already passed |
| ⏩ | `skipped` | Skipped |
| ⌛ | `wait_device` | Waiting device |
| ⏱ | `wait_device_timeout` | Device timeout |
| ⏳ | `waiting` | Waiting |
| ❔ | anything unrecognised | None |

⏩ and ✅⏩ are a pair: the fast-forward means skipped, and the check in front of it means skipped because it had already passed. That only reads if `skipped` owns the fast-forward on its own, which is why it moved off the sleep glyph.

🚫 for `internal_error` matches the `ban` icon the Mobile UI already uses for it. ⏹ for `canceled` and ⏩ for `skipped` read as media controls: stopping a run, skipping past a cell.

`failed`, `queuing` and `skipped` also exist in `src/autify/web/waitTestResult.ts`, which keeps its own copy of this function, so all three changed there too. Leaving them out of step would mean `autify web` and `autify mobile` disagreeing about what a failed test looks like. Seven recorded lines in the web snapshots carried the old queuing glyph; `failed` and `skipped` appear in no snapshot on either side.

`skipped`, `failed` and `queuing` also exist in `src/autify/web/waitTestResult.ts`, which keeps its own copy of this function. Only `skipped` changed here, so web still shows 💤 for it. Worth reconciling, but in its own change rather than this one.




